### PR TITLE
feat: support operations on objects to add metadata (mark, review, etc.)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,12 +5,9 @@
 * [ ] Rework documentation `linter.md` and introduce a new `config.md`
 * [ ] Add tests for `GeneratorPreprocessor`
 
-## TODO: Features
-
-* [ ] Implement operations using CRDT datatypes
-
 ## TODO: Sprint
 
+* [ ] Fix unit test `TestEvaluateTimeExpressionAfter`
 * [ ] Implement `GC()` on remotes
 * [ ] Implement option `-i` in `nt pull`/`nt push`
 * [ ] Add tests on `ObjectDiffs` for `Patch`/etc.
@@ -18,5 +15,6 @@
 
 ## TODO: Improvement
 
+* [ ] Move Datastore method on `DB`
 * [ ] Add a "Cheatsheet: Fixtures using `testdata`" + "Cheatsheet: Fixtures using raw files" in notes
 * [ ] Write custom assertion to compare `ToJSON` and `ToYAML` ignore spaces

--- a/cmd/nt/cat_file.go
+++ b/cmd/nt/cat_file.go
@@ -59,7 +59,7 @@ func dumpOID(oid oid.OID) {
 		dumpObject(object)
 		return
 	}
-	blob, err := core.CurrentDB().Index().ReadBlob(oid)
+	blob, err := core.CurrentIndex().ReadBlob(oid)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to read blob: %v", err)
 		os.Exit(1)

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -182,20 +182,62 @@ func (db *DB) Client() SQLClient {
 	return db.initClient()
 }
 
+/* Object Management */
+
+// ReadObject reads an object from the internal SQL database.
+func (db *DB) ReadObject(oid oid.OID, kind string) (Object, error) {
+	switch kind {
+	case "file":
+		return CurrentRepository().LoadFileByOID(oid)
+	case "note":
+		return CurrentRepository().LoadNoteByOID(oid)
+	case "flashcard":
+		return CurrentRepository().LoadFlashcardByOID(oid)
+	case "media":
+		return CurrentRepository().LoadMediaByOID(oid)
+	case "reminder":
+		return CurrentRepository().LoadReminderByOID(oid)
+	default:
+		return nil, fmt.Errorf("unknown object kind %q", kind)
+	}
+}
+
 /* PackFile Management */
 
 // UpsertPackFiles inserts or updates pack files in the database.
 func (db *DB) UpsertPackFiles(packFiles ...*PackFile) error {
 	for _, packFile := range packFiles {
 		for _, object := range packFile.PackObjects {
-			obj := object.ReadObject()
+			obj := object.Read()
 			if statefulObj, ok := obj.(StatefulObject); ok {
 				if err := statefulObj.Save(); err != nil {
 					return err
 				}
 			}
-			CurrentLogger().Infof("💾 Upserted pack file %s", filepath.Base(packFile.ObjectPath()))
+			if operation, ok := obj.(*Operation); ok {
+				// Save the operation in the database
+				// Reread the object from SQL database to have metadata too
+				indexObject := CurrentIndex().GetPackFileObject(operation.ObjectOID)
+				if !ok {
+					return fmt.Errorf("object %s is not present in index for operation %s", operation.ObjectOID, operation.OID)
+				}
+				obj, err := db.ReadObject(indexObject.OID, indexObject.Kind)
+				if err != nil {
+					return fmt.Errorf("unable to read object %s for operation %s: %w", operation.ObjectOID, operation.OID, err)
+				}
+				statefulObj, ok := obj.(StatefulObject)
+				if !ok {
+					return fmt.Errorf("object %s is not a stateful object for operation %s", operation.ObjectOID, operation.OID)
+				}
+				if _, err := operation.Apply(statefulObj); err != nil {
+					return fmt.Errorf("unable to apply operation %s on object %s: %w", operation.OID, operation.ObjectOID, err)
+				}
+				if err := statefulObj.SaveMetadata(); err != nil {
+					return fmt.Errorf("unable to save object %s: %w", statefulObj.UniqueOID(), err)
+				}
+			}
 		}
+		CurrentLogger().Infof("💾 Upserted pack file %s", filepath.Base(packFile.ObjectPath()))
 	}
 	return nil
 }
@@ -204,13 +246,14 @@ func (db *DB) UpsertPackFiles(packFiles ...*PackFile) error {
 func (db *DB) DeletePackFiles(packFiles ...*PackFile) error {
 	for _, packFile := range packFiles {
 		for _, object := range packFile.PackObjects {
-			obj := object.ReadObject()
+			obj := object.Read()
 			if statefulObj, ok := obj.(StatefulObject); ok {
 				if err := statefulObj.Delete(); err != nil {
 					return err
 				}
 				CurrentLogger().Infof("💾 Deleted pack file %s", filepath.Base(packFile.ObjectPath()))
 			}
+			// Ignore operations
 		}
 	}
 	return nil
@@ -239,7 +282,6 @@ func (db *DB) WritePackFileOnDisk(packFile *PackFile) error {
 	if err := packFile.Save(); err != nil {
 		return err
 	}
-	CurrentLogger().Infof("💾 Saved pack file %s", filepath.Base(packFile.ObjectPath()))
 	return nil
 }
 

--- a/internal/core/file.go
+++ b/internal/core/file.go
@@ -347,6 +347,11 @@ func (f *File) Save() error {
 	return nil
 }
 
+func (f *File) SaveMetadata() error {
+	// No operation-related fields for now
+	return nil
+}
+
 func (f *File) Delete() error {
 	CurrentLogger().Debugf("Deleting file %s...", f.RelativePath)
 	query := `DELETE FROM file WHERE oid = ? AND packfile_oid = ?;`
@@ -384,13 +389,6 @@ func (r *Repository) FindFileByWikilink(wikilink string) (*File, error) {
 
 func (r *Repository) FindFilesByWikilink(wikilink string) ([]*File, error) {
 	return QueryFiles(CurrentDB().Client(), `WHERE wikilink LIKE ?`, "%"+text.TrimExtension(wikilink))
-}
-
-func (r *Repository) FindFilesLastCheckedBefore(point time.Time, path string) ([]*File, error) {
-	if path == "." {
-		path = ""
-	}
-	return QueryFiles(CurrentDB().Client(), `WHERE indexed_at < ? AND relative_path LIKE ?`, timeToSQL(point), path+"%")
 }
 
 // CountFiles returns the total number of files.

--- a/internal/core/flashcard.go
+++ b/internal/core/flashcard.go
@@ -75,9 +75,9 @@ type Flashcard struct {
 	IndexedAt time.Time `yaml:"indexed_at,omitempty" json:"indexed_at,omitempty"`
 
 	// SRS
-	DueAt     time.Time      `yaml:"due_at,omitempty" json:"due_at,omitempty"`
-	StudiedAt time.Time      `yaml:"studied_at,omitempty" json:"studied_at,omitempty"`
-	Settings  map[string]any `yaml:"settings,omitempty" json:"settings,omitempty"`
+	DueAt     time.Time      `yaml:"-" json:"-"`
+	StudiedAt time.Time      `yaml:"-" json:"-"`
+	Settings  map[string]any `yaml:"-" json:"-"`
 }
 
 type Study struct {
@@ -321,6 +321,7 @@ func (f *Flashcard) Save() error {
 			indexed_at = ?
 		;
 		`
+
 	_, err := CurrentDB().Client().Exec(query,
 		// Insert
 		f.OID,
@@ -348,6 +349,36 @@ func (f *Flashcard) Save() error {
 		f.Back,
 		timeToSQL(f.UpdatedAt),
 		timeToSQL(f.IndexedAt),
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *Flashcard) SaveMetadata() error {
+	CurrentLogger().Debugf("Saving flashcard %s...", f.ShortTitle)
+	query := `
+		UPDATE flashcard
+		SET
+			due_at = ?,
+			studied_at = ?,
+			settings = ?
+		WHERE oid = ?
+		;
+		`
+
+	settingsJSON, err := json.MarshalIndent(f.Settings, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = CurrentDB().Client().Exec(query,
+		timeToSQL(f.DueAt),
+		timeToSQL(f.StudiedAt),
+		settingsJSON,
+		f.OID,
 	)
 	if err != nil {
 		return err
@@ -427,13 +458,6 @@ func (r *Repository) FindFlashcardByShortTitle(shortTitle string) (*Flashcard, e
 
 func (r *Repository) FindFlashcardByHash(hash string) (*Flashcard, error) {
 	return QueryFlashcard(CurrentDB().Client(), `WHERE hash = ?`, hash)
-}
-
-func (r *Repository) FindFlashcardsLastCheckedBefore(point time.Time, path string) ([]*Flashcard, error) {
-	if path == "." {
-		path = ""
-	}
-	return QueryFlashcards(CurrentDB().Client(), `WHERE indexed_at < ? AND relative_path LIKE ?`, timeToSQL(point), path+"%")
 }
 
 /* SQL Helpers */
@@ -737,3 +761,23 @@ lapses INTEGER NOT NULL DEFAULT 0,
 --    for example: '2004' means 2 reps left today and 4 reps till graduation
 left INTEGER NOT NULL DEFAULT 0,
 */
+
+/* Operations */
+
+type FlashcardReview struct {
+	Feedback Feedback       `yaml:"feedback" json:"feedback"`
+	Duration time.Duration  `duration:"duration" json:"duration"`
+	DueAt    time.Time      `yaml:"due_at" json:"due_at"`
+	Settings map[string]any `yaml:"settings" json:"settings"`
+}
+
+// Review updates the flashcard following a review.
+func (f *Flashcard) Review(studiedAt time.Time, review *FlashcardReview) {
+	if !f.StudiedAt.IsZero() && f.StudiedAt.After(studiedAt) {
+		// The studiedAt timestamp is in the past. Ignore this review.
+		return
+	}
+	f.StudiedAt = studiedAt
+	f.DueAt = review.DueAt
+	f.Settings = review.Settings
+}

--- a/internal/core/flashcard_test.go
+++ b/internal/core/flashcard_test.go
@@ -132,9 +132,7 @@ indexed_at: 2023-01-01T01:12:30Z
   "back": "A **gopher**.",
   "created_at": "2023-01-01T01:12:30Z",
   "updated_at": "2023-01-01T01:12:30Z",
-  "indexed_at": "2023-01-01T01:12:30Z",
-  "due_at": "0001-01-01T00:00:00Z",
-  "studied_at": "0001-01-01T00:00:00Z"
+  "indexed_at": "2023-01-01T01:12:30Z"
 }
 `)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(actual))
@@ -150,6 +148,75 @@ What does the **Golang logo** represent?
 A **gopher**.
 `)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(actual))
+	})
+
+}
+
+func TestFlashcardOperations(t *testing.T) {
+
+	t.Run("Review", func(t *testing.T) {
+		SetUpRepositoryFromTempDir(t)
+		FreezeOn(t, "2025-02-01 12:00:00")
+
+		// Insert the note
+		MustWriteFile(t, "python.md", `# Python
+
+## Flashcard: Python's creator
+
+Who invented Python?
+
+---
+
+Guido van Rossum
+`)
+
+		err := CurrentRepository().Add(PathSpecs{"python.md"})
+		require.NoError(t, err)
+		err = CurrentRepository().Commit()
+		require.NoError(t, err)
+
+		// Review the flashcard
+		firstStudyAt := clock.Now().Add(1 * time.Hour)
+		flashcard, err := CurrentRepository().FindFlashcardByShortTitle("Python's creator")
+		require.NoError(t, err)
+		require.NotNil(t, flashcard)
+		flashcard.Review(firstStudyAt, &FlashcardReview{
+			Feedback: FeedbackEasy,
+			Duration: 1 * time.Second,
+			DueAt:    firstStudyAt.Add(24 * time.Hour),
+			Settings: map[string]any{
+				"easeFactor": 2500,
+			},
+		})
+		require.NoError(t, flashcard.SaveMetadata())
+
+		// Check the flashcard
+		flashcard, err = CurrentRepository().FindFlashcardByShortTitle("Python's creator")
+		require.NoError(t, err)
+		require.NotNil(t, flashcard)
+		assert.EqualValues(t, firstStudyAt, flashcard.StudiedAt)
+		assert.EqualValues(t, firstStudyAt.Add(24*time.Hour), flashcard.DueAt)
+		assert.Equal(t, 2500, flashcard.Settings["easeFactor"])
+
+		// Review again
+		secondStudyAt := firstStudyAt.Add(1 * time.Hour)
+		flashcard.Review(secondStudyAt, &FlashcardReview{
+			Feedback: FeedbackHard,
+			Duration: 2 * time.Second,
+			DueAt:    secondStudyAt.Add(1 * time.Hour),
+			Settings: map[string]any{
+				"easeFactor": 2300,
+			},
+		})
+		require.NoError(t, flashcard.SaveMetadata())
+
+		// Check again
+		flashcard, err = CurrentRepository().FindFlashcardByShortTitle("Python's creator")
+		require.NoError(t, err)
+		require.NotNil(t, flashcard)
+		assert.EqualValues(t, secondStudyAt, flashcard.StudiedAt)
+		assert.EqualValues(t, secondStudyAt.Add(1*time.Hour), flashcard.DueAt)
+		assert.Equal(t, 2300, flashcard.Settings["easeFactor"])
 	})
 
 }

--- a/internal/core/go_link.go
+++ b/internal/core/go_link.go
@@ -230,6 +230,11 @@ func (l *GoLink) Save() error {
 	return nil
 }
 
+func (l *GoLink) SaveMetadata() error {
+	// No operation-related fields for now
+	return nil
+}
+
 func (l *GoLink) Delete() error {
 	CurrentLogger().Debugf("Deleting link %s...", l.GoName)
 	query := `DELETE FROM link WHERE oid = ? AND packfile_oid = ?;`
@@ -259,13 +264,6 @@ func (r *Repository) FindGoLinkByGoName(goName string) (*GoLink, error) {
 
 func (r *Repository) FindGoLinksByText(text string) ([]*GoLink, error) {
 	return QueryGoLinks(CurrentDB().Client(), "WHERE text = ?", text)
-}
-
-func (r *Repository) FindGoLinksLastCheckedBefore(point time.Time, path string) ([]*GoLink, error) {
-	if path == "." {
-		path = ""
-	}
-	return QueryGoLinks(CurrentDB().Client(), `WHERE indexed_at < ? AND relative_path LIKE ?`, timeToSQL(point), path+"%")
 }
 
 /* SQL Helpers */

--- a/internal/core/index.go
+++ b/internal/core/index.go
@@ -332,6 +332,37 @@ func (i *Index) GetParentEntry(relativePath string) *IndexEntry {
 	}
 }
 
+// Add indexes new pack files without staging them first (useful for operations).
+func (i *Index) Add(packFiles ...*PackFile) error {
+	for _, packFile := range packFiles {
+		entry := i.GetEntry(packFile.FileRelativePath)
+		if entry == nil {
+			entry = NewIndexEntry(packFile)
+			i.Entries = append(i.Entries, entry)
+		}
+		entry.PackFileOID = packFile.OID
+		entry.MTime = time.Time{}
+		entry.Size = 0
+		entry.Staged = false
+		// Update caches
+		for _, packObject := range packFile.PackObjects {
+			i.Objects = append(i.Objects, &IndexObject{
+				OID:         packObject.OID,
+				Kind:        packObject.Kind,
+				PackFileOID: packFile.OID,
+			})
+		}
+		for _, blob := range packFile.BlobRefs {
+			i.Blobs = append(i.Blobs, &IndexBlob{
+				OID:         blob.OID,
+				MimeType:    blob.MimeType,
+				PackFileOID: packFile.OID,
+			})
+		}
+	}
+	return nil
+}
+
 // Stage indexes new pack files.
 // The pack files can match files already indexed by a previous pack file.
 func (i *Index) Stage(packFiles ...*PackFile) error {
@@ -591,13 +622,26 @@ func (i *Index) ReadPackObject(oid oid.OID) (*PackObject, error) {
 	return nil, nil
 }
 
+// ReadPackable reads an object from the index.
+func (i *Index) ReadPackable(oid oid.OID) (Packable, error) {
+	packObject, err := i.ReadPackObject(oid)
+	if err != nil {
+		return nil, err
+	}
+	return packObject.Read(), nil
+}
+
 // ReadObject reads an object from the index.
 func (i *Index) ReadObject(oid oid.OID) (Object, error) {
 	packObject, err := i.ReadPackObject(oid)
 	if err != nil {
 		return nil, err
 	}
-	return packObject.ReadObject(), nil
+	object, ok := packObject.Read().(Object)
+	if !ok {
+		return nil, fmt.Errorf("object %q is not a valid object", oid)
+	}
+	return object, nil
 }
 
 // ReadBlob reads a blob from the index.

--- a/internal/core/media.go
+++ b/internal/core/media.go
@@ -431,6 +431,11 @@ func (m *Media) Save() error {
 	return nil
 }
 
+func (m *Media) SaveMetadata() error {
+	// No operation-related fields for now
+	return nil
+}
+
 func (m *Media) InsertBlobs() error {
 	if err := m.DeleteBlobs(); err != nil {
 		return err
@@ -540,10 +545,6 @@ func (r *Repository) FindMediaByRelativePath(relativePath string) (*Media, error
 
 func (r *Repository) FindMediaByHash(hash string) (*Media, error) {
 	return QueryMedia(CurrentDB().Client(), `WHERE hashsum = ?`, hash)
-}
-
-func (r *Repository) FindMediasLastCheckedBefore(point time.Time) ([]*Media, error) {
-	return QueryMedias(CurrentDB().Client(), `WHERE indexed_at < ?`, timeToSQL(point))
 }
 
 func (r *Repository) FindBlobsFromMedia(mediaOID oid.OID) ([]*BlobRef, error) {

--- a/internal/core/note.go
+++ b/internal/core/note.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -66,6 +67,11 @@ type Note struct {
 	CreatedAt time.Time `yaml:"created_at" json:"created_at"`
 	UpdatedAt time.Time `yaml:"updated_at" json:"updated_at"`
 	IndexedAt time.Time `yaml:"indexed_at,omitempty" json:"indexed_at,omitempty"`
+
+	// Operation-related fields (not mapped in object representation but using CDRTs)
+	Marked      bool         `yaml:"-" json:"-"`
+	MarkedAt    time.Time    `yaml:"-" json:"-"`
+	Annotations []Annotation `yaml:"-" json:"-"`
 }
 
 // NewNote creates a new note.
@@ -91,6 +97,8 @@ func NewNote(packFile *PackFile, file *File, parsedNote *ParsedNote) (*Note, err
 		CreatedAt:    packFile.CTime,
 		UpdatedAt:    packFile.CTime,
 		IndexedAt:    packFile.CTime,
+		// Operation-related fields
+		Marked: false,
 	}
 
 	return n, nil
@@ -493,6 +501,36 @@ func (n *Note) Save() error {
 	return nil
 }
 
+func (n *Note) SaveMetadata() error {
+	CurrentLogger().Debugf("Saving note %s...", n.Wikilink)
+	query := `
+		UPDATE note
+		SET
+			marked = ?,
+			marked_at = ?,
+			annotations = ?
+		WHERE oid = ?
+		;
+	`
+
+	annotationsJSON, err := json.MarshalIndent(n.Annotations, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = CurrentDB().Client().Exec(query,
+		n.Marked,
+		timeToSQL(n.MarkedAt),
+		annotationsJSON,
+		n.OID,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (n *Note) Delete() error {
 	CurrentLogger().Debugf("Deleting note %s...", n.Wikilink)
 	query := `DELETE FROM note WHERE oid = ? AND packfile_oid = ?;`
@@ -686,13 +724,6 @@ func (r *Repository) FindNotesByWikilink(wikilink string) ([]*Note, error) {
 	return QueryNotes(CurrentDB().Client(), `WHERE wikilink LIKE ?`, "%"+wikilink)
 }
 
-func (r *Repository) FindNotesLastCheckedBefore(point time.Time, path string) ([]*Note, error) {
-	if path == "." {
-		path = ""
-	}
-	return QueryNotes(CurrentDB().Client(), `WHERE indexed_at < ? AND relative_path LIKE ?`, timeToSQL(point), path+"%")
-}
-
 // SearchNotes query notes to find the ones matching a list of criteria.
 //
 // Examples:
@@ -772,8 +803,10 @@ func QueryNote(db SQLClient, whereClause string, args ...any) (*Note, error) {
 	var createdAt string
 	var updatedAt string
 	var lastIndexedAt string
+	var markedAt sql.NullString
 	var tagsRaw string
 	var attributesRaw string
+	var annotationsRaw string
 
 	// Query for a value based on a single row.
 	if err := db.QueryRow(fmt.Sprintf(`
@@ -797,7 +830,10 @@ func QueryNote(db SQLClient, whereClause string, args ...any) (*Note, error) {
 			comment,
 			created_at,
 			updated_at,
-			indexed_at
+			indexed_at,
+			marked,
+			marked_at,
+			annotations
 		FROM note
 		%s;`, whereClause), args...).
 		Scan(
@@ -821,6 +857,9 @@ func QueryNote(db SQLClient, whereClause string, args ...any) (*Note, error) {
 			&createdAt,
 			&updatedAt,
 			&lastIndexedAt,
+			&n.Marked,
+			&markedAt,
+			&annotationsRaw,
 		); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -833,11 +872,21 @@ func QueryNote(db SQLClient, whereClause string, args ...any) (*Note, error) {
 		return nil, err
 	}
 
+	annotations := make([]Annotation, 0)
+	if annotationsRaw != "" {
+		err = yaml.Unmarshal([]byte(annotationsRaw), &annotations)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	n.Attributes = attributes.CastOrIgnore(CurrentConfigFile().Attributes)
 	n.Tags = strings.Split(tagsRaw, ",")
 	n.CreatedAt = timeFromSQL(createdAt)
 	n.UpdatedAt = timeFromSQL(updatedAt)
 	n.IndexedAt = timeFromSQL(lastIndexedAt)
+	n.MarkedAt = timeFromNullableSQL(markedAt)
+	n.Annotations = annotations
 
 	return &n, nil
 }
@@ -866,7 +915,10 @@ func QueryNotes(db SQLClient, whereClause string, args ...any) ([]*Note, error) 
 			comment,
 			created_at,
 			updated_at,
-			indexed_at
+			indexed_at,
+			marked,
+			marked_at,
+			annotations
 		FROM note
 		%s;`, whereClause), args...)
 	if err != nil {
@@ -878,8 +930,10 @@ func QueryNotes(db SQLClient, whereClause string, args ...any) ([]*Note, error) 
 		var createdAt string
 		var updatedAt string
 		var lastIndexedAt string
+		var markedAt sql.NullString
 		var tagsRaw string
 		var attributesRaw string
+		var annotationsRaw string
 
 		err = rows.Scan(
 			&n.OID,
@@ -902,6 +956,9 @@ func QueryNotes(db SQLClient, whereClause string, args ...any) ([]*Note, error) 
 			&createdAt,
 			&updatedAt,
 			&lastIndexedAt,
+			&n.Marked,
+			&markedAt,
+			&annotationsRaw,
 		)
 		if err != nil {
 			return nil, err
@@ -912,11 +969,22 @@ func QueryNotes(db SQLClient, whereClause string, args ...any) ([]*Note, error) 
 			return nil, err
 		}
 
+		annotations := make([]Annotation, 0)
+		if annotationsRaw != "" {
+			err = yaml.Unmarshal([]byte(annotationsRaw), &annotations)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		n.Attributes = attributes.CastOrIgnore(CurrentConfigFile().Attributes)
 		n.Tags = strings.Split(tagsRaw, ",")
 		n.CreatedAt = timeFromSQL(createdAt)
 		n.UpdatedAt = timeFromSQL(updatedAt)
 		n.IndexedAt = timeFromSQL(lastIndexedAt)
+		n.MarkedAt = timeFromNullableSQL(markedAt)
+		n.Annotations = annotations
+
 		notes = append(notes, &n)
 	}
 
@@ -944,4 +1012,77 @@ func (n *Note) ToMarkdown() string {
 	sb.WriteRune('\n')
 	sb.WriteString(string(n.Body))
 	return sb.String()
+}
+
+/* Operations */
+
+// Mark set a flag on the note.
+func (n *Note) Mark(timestamp time.Time) {
+	if n.MarkedAt.IsZero() {
+		n.Marked = true
+		n.MarkedAt = timestamp
+		return
+	}
+
+	if n.MarkedAt.After(timestamp) {
+		// Ignore out-of-order operations
+		return
+	}
+
+	n.Marked = true
+	n.MarkedAt = timestamp
+}
+
+// Unmark set a flag on the note.
+func (n *Note) Unmark(timestamp time.Time) {
+	if n.MarkedAt.IsZero() {
+		n.Marked = false
+		n.MarkedAt = timestamp
+		return
+	}
+
+	if n.MarkedAt.After(timestamp) {
+		// Ignore out-of-order operations
+		return
+	}
+
+	n.Marked = false
+	n.MarkedAt = timestamp
+}
+
+type Annotation struct {
+	OID       oid.OID   `yaml:"oid" json:"oid"`
+	Text      string    `yaml:"text" json:"text"`
+	CreatedAt time.Time `yaml:"created_at" json:"created_at"`
+}
+
+// AddAnnotation adds an annotation to the note.
+func (n *Note) AddAnnotation(timestamp time.Time, annotation Annotation) {
+	for _, existing := range n.Annotations {
+		if existing.OID == annotation.OID {
+			// Ignore out-of-order operations
+			if existing.CreatedAt.Before(timestamp) {
+				// Remove before inserting the updated annotation
+				n.RemoveAnnotation(timestamp, existing)
+			}
+			break
+		}
+	}
+
+	annotation.CreatedAt = timestamp
+	n.Annotations = append(n.Annotations, annotation)
+}
+
+// RemoveAnnotation removes an annotation from the note.
+func (n *Note) RemoveAnnotation(timestamp time.Time, annotation Annotation) {
+	for i, existing := range n.Annotations {
+		if existing.OID == annotation.OID {
+			// Ignore out-of-order operations
+			if existing.CreatedAt.Before(timestamp) {
+				// Remove existing annotation
+				n.Annotations = append(n.Annotations[:i], n.Annotations[i+1:]...)
+				return
+			}
+		}
+	}
 }

--- a/internal/core/note_test.go
+++ b/internal/core/note_test.go
@@ -272,3 +272,127 @@ func TestSearchNotes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, notes, 0)
 }
+
+func TestNoteOperations(t *testing.T) {
+
+	t.Run("Mark and Unmark", func(t *testing.T) {
+		SetUpRepositoryFromTempDir(t)
+
+		// Insert the note
+		MustWriteFile(t, "python.md", `# Python
+
+## Flashcard: Python's creator
+
+Who invented Python?
+
+---
+
+Guido van Rossum
+`)
+
+		err := CurrentRepository().Add(PathSpecs{"python.md"})
+		require.NoError(t, err)
+		err = CurrentRepository().Commit()
+		require.NoError(t, err)
+
+		// Check the note is present
+		note := MustFindNoteByTitle(t, "Flashcard: Python's creator")
+
+		// Mark the note
+		note.Mark(clock.Now())
+
+		// Save the note
+		require.NoError(t, note.SaveMetadata())
+
+		// Reread the note and check the marked status
+		note, err = CurrentRepository().LoadNoteByOID(note.OID)
+		require.NoError(t, err)
+		assert.True(t, note.Marked)
+
+		// Unmark the note, save it, and check the status
+		note.Unmark(clock.Now())
+		require.NoError(t, note.SaveMetadata())
+		note, err = CurrentRepository().LoadNoteByOID(note.OID)
+		require.NoError(t, err)
+		assert.False(t, note.Marked)
+	})
+
+	t.Run("Annotate", func(t *testing.T) {
+		SetUpRepositoryFromTempDir(t)
+		c := FreezeNow(t)
+
+		date1 := clock.Now()
+
+		// Insert the note
+		MustWriteFile(t, "python.md", `# Python
+
+## Flashcard: Python's creator
+
+Who invented Python?
+
+---
+
+Guido van Rossum
+`)
+
+		err := CurrentRepository().Add(PathSpecs{"python.md"})
+		require.NoError(t, err)
+		err = CurrentRepository().Commit()
+		require.NoError(t, err)
+
+		// Check the note is present
+		note := MustFindNoteByTitle(t, "Flashcard: Python's creator")
+
+		// Mark the note
+		note.AddAnnotation(clock.Now(), Annotation{
+			OID:  "42d74d967d9b4e989502647ac510777ca1e22f4a",
+			Text: "Use Markdown emphasis",
+		})
+
+		// Save the note
+		require.NoError(t, note.SaveMetadata())
+
+		// Reread the note and check the annotation has been saved
+		note, err = CurrentRepository().LoadNoteByOID(note.OID)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(note.Annotations))
+		assert.Equal(t, "Use Markdown emphasis", note.Annotations[0].Text)
+		assert.Equal(t, date1.UTC(), note.Annotations[0].CreatedAt.UTC())
+
+		c.FastForward(1 * time.Hour)
+		date2 := clock.Now()
+
+		// Add a second annotation
+		note.AddAnnotation(clock.Now(), Annotation{
+			OID:  "639c1b9964ad45c9b50cb79c2daa03b59f57a01d",
+			Text: "Delete",
+		})
+		require.NoError(t, note.SaveMetadata())
+		note, err = CurrentRepository().LoadNoteByOID(note.OID)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(note.Annotations))
+		assert.Equal(t, "Use Markdown emphasis", note.Annotations[0].Text)
+		assert.Equal(t, date1.UTC(), note.Annotations[0].CreatedAt.UTC())
+		assert.Equal(t, "Delete", note.Annotations[1].Text)
+		assert.Equal(t, date2.UTC(), note.Annotations[1].CreatedAt.UTC())
+
+		// Delete the first annotation
+		note.RemoveAnnotation(clock.Now(), note.Annotations[0])
+		require.NoError(t, note.SaveMetadata())
+		note, err = CurrentRepository().LoadNoteByOID(note.OID)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(note.Annotations))
+		assert.Equal(t, "Delete", note.Annotations[0].Text)
+		assert.Equal(t, date2.UTC(), note.Annotations[0].CreatedAt.UTC())
+	})
+
+}
+
+/* Helpers */
+
+func MustFindNoteByTitle(t *testing.T, title string) *Note {
+	note, err := CurrentRepository().FindNoteByTitle(title)
+	require.NoError(t, err)
+	require.NotNil(t, note)
+	return note
+}

--- a/internal/core/object.go
+++ b/internal/core/object.go
@@ -75,24 +75,10 @@ type Dumpable interface {
 // groups different kinds of objects inside the same object.
 type Object interface {
 	Dumpable
-
-	// Kind returns the object kind to determine which kind of object to create.
-	Kind() string
-	// UniqueOID returns the OID of the object.
-	UniqueOID() oid.OID
-	// ModificationTime returns the last modification time.
-	ModificationTime() time.Time
+	Packable
 
 	// Relations returns the relations where the current object is the source.
 	Relations() []*Relation
-
-	// Read rereads the object from YAML.
-	Read(r io.Reader) error
-	// Write writes the object to YAML.
-	Write(w io.Writer) error
-
-	// String returns a one-line description
-	String() string
 
 	// Update website/guides/devolopers/presentation.md
 }
@@ -110,8 +96,10 @@ type ParsedObject interface {
 type StatefulObject interface {
 	Object
 
-	// Save persists to DB
+	// Save persists object-related columns to DB
 	Save() error
+	// SaveMetadata persists operation-related columns to DB
+	SaveMetadata() error
 	// Delete removes from DB
 	Delete() error
 
@@ -190,6 +178,29 @@ func (r BlobRefs) OIDs() []oid.OID {
 		results = append(results, ref.OID)
 	}
 	return results
+}
+
+// MustAppendObject registers a new object inside the pack file or panic.
+func (p *PackFile) MustAppendObject(obj Object) {
+	if err := p.AppendObject(obj); err != nil {
+		panic(err)
+	}
+}
+
+// AppendObject registers a new object inside the pack file.
+func (p *PackFile) AppendObject(obj Object) error {
+	data, err := NewObjectData(obj)
+	if err != nil {
+		return err
+	}
+	p.PackObjects = append(p.PackObjects, &PackObject{
+		OID:         obj.UniqueOID(),
+		Kind:        obj.Kind(),
+		CTime:       obj.ModificationTime(),
+		Description: obj.String(),
+		Data:        data,
+	})
+	return nil
 }
 
 /* Utility */

--- a/internal/core/operations.go
+++ b/internal/core/operations.go
@@ -1,0 +1,270 @@
+package core
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/julien-sobczak/the-notewriter/pkg/clock"
+	"github.com/julien-sobczak/the-notewriter/pkg/oid"
+	"gopkg.in/yaml.v3"
+)
+
+// Operation represents a change to a StatefulObject.
+//
+// Operations use the CRDT (Conflict-free Replicated Data Type) model to ensure that
+// changes can be applied in any order and still result in the same final state.
+// Each operation has a timestamp that is used to resolve conflicts (LWW = last write wins).
+//
+// See https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type
+type Operation struct {
+	OID       oid.OID        `json:"oid" yaml:"oid"`
+	ObjectOID oid.OID        `json:"object_oid" yaml:"object_oid"` // OID of the object this operation applies to
+	Name      string         `json:"name" yaml:"name"`
+	Timestamp time.Time      `json:"timestamp" yaml:"timestamp"`
+	Extras    map[string]any `yaml:",inline"` // Capture extra fields
+}
+
+// NewOperationMarkNote creates a new operation to mark a note.
+func NewOperationMarkNote(noteOID oid.OID) *Operation {
+	return &Operation{
+		OID:       oid.New(),
+		ObjectOID: noteOID,
+		Name:      "mark-note",
+		Timestamp: clock.Now(),
+	}
+}
+
+// NewOperationUnmarkNote creates a new operation to mark a note.
+func NewOperationUnmarkNote(noteOID oid.OID) *Operation {
+	return &Operation{
+		OID:       oid.New(),
+		ObjectOID: noteOID,
+		Name:      "unmark-note",
+		Timestamp: clock.Now(),
+	}
+}
+
+// NewOperationAddAnnotation creates a new operation to add an annotation to a note.
+func NewOperationAddAnnotation(noteOID oid.OID, annotation Annotation) *Operation {
+	return &Operation{
+		OID:       oid.New(),
+		ObjectOID: noteOID,
+		Name:      "add-annotation",
+		Timestamp: clock.Now(),
+		Extras:    map[string]any{"annotation": annotation},
+	}
+}
+
+// NewOperationRemoveAnnotation creates a new operation to remove an annotation from a note.
+func NewOperationRemoveAnnotation(noteOID oid.OID, annotation Annotation) *Operation {
+	return &Operation{
+		OID:       oid.New(),
+		ObjectOID: noteOID,
+		Name:      "remove-annotation",
+		Timestamp: clock.Now(),
+		Extras:    map[string]any{"annotation": annotation},
+	}
+}
+
+// NewOperationCompleteReminder creates a new operation to complete a reminder.
+func NewOperationCompleteReminder(reminderOID oid.OID) *Operation {
+	return &Operation{
+		OID:       oid.New(),
+		ObjectOID: reminderOID,
+		Name:      "complete-reminder",
+		Timestamp: clock.Now(),
+	}
+}
+
+// NewOperationReviewFlashcard creates a new operation to review a flashcard.
+func NewOperationReviewFlashcard(flashcardOID oid.OID, review FlashcardReview) *Operation {
+	return &Operation{
+		OID:       oid.New(),
+		ObjectOID: flashcardOID,
+		Name:      "review-flashcard",
+		Timestamp: clock.Now(),
+		Extras:    map[string]any{"review": review},
+	}
+}
+
+/* Operations Implementation */
+
+type OperationFn func(obj StatefulObject, operation *Operation) (StatefulObject, error)
+
+var operationFns = map[string]OperationFn{
+	"mark-note":         MarkNote,
+	"unmark-note":       UnmarkNote,
+	"add-annotation":    AddAnnotation,
+	"remove-annotation": RemoveAnnotation,
+	"complete-reminder": CompleteReminder,
+	"review-flashcard":  ReviewFlashcard,
+	// Add more operations here
+}
+
+/* Packable interface */
+
+func (o *Operation) Kind() string {
+	return "operation"
+}
+func (o *Operation) UniqueOID() oid.OID {
+	return o.OID
+}
+func (o *Operation) Read(r io.Reader) error {
+	err := yaml.NewDecoder(r).Decode(o)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (o *Operation) Write(w io.Writer) error {
+	data, err := yaml.Marshal(o)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func (o *Operation) ModificationTime() time.Time {
+	return o.Timestamp
+}
+
+func (o *Operation) String() string {
+	return fmt.Sprintf("Operation %s on object %q", o.Name, o.OID)
+}
+
+/* Operation functions */
+
+// parseExtras parses the extras field of the operation into the given expected type.
+func (o *Operation) parseExtras(fieldName string, v any) error {
+	value, ok := o.Extras[fieldName]
+	if !ok {
+		return fmt.Errorf("missing field %q in extras", fieldName)
+	}
+	b, err := yaml.Marshal(value)
+	if err != nil {
+		return err
+	}
+	if err := yaml.Unmarshal(b, v); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Apply applies the operation to the given object.
+func (o *Operation) Apply(obj StatefulObject) (StatefulObject, error) {
+	fn, ok := operationFns[o.Name]
+	if !ok {
+		return nil, fmt.Errorf("operation %q not found", o.Name)
+	}
+	return fn(obj, o)
+}
+
+/*
+ * Mark/Unmark a note
+ */
+
+func MarkNote(obj StatefulObject, operation *Operation) (StatefulObject, error) {
+	note, ok := obj.(*Note)
+	if !ok {
+		return nil, fmt.Errorf("object %q is not a note", obj.UniqueOID())
+	}
+	note.Mark(operation.Timestamp)
+	return note, nil
+}
+
+func UnmarkNote(obj StatefulObject, operation *Operation) (StatefulObject, error) {
+	note, ok := obj.(*Note)
+	if !ok {
+		return nil, fmt.Errorf("object %q is not a note", obj.UniqueOID())
+	}
+	note.Unmark(operation.Timestamp)
+	return note, nil
+}
+
+/*
+ * Review a flashcard
+ */
+
+func ReviewFlashcard(obj StatefulObject, operation *Operation) (StatefulObject, error) {
+	flashcard, ok := obj.(*Flashcard)
+	if !ok {
+		return nil, fmt.Errorf("object %q is not a flashcard", obj.UniqueOID())
+	}
+	var review FlashcardReview
+	if err := operation.parseExtras("review", &review); err != nil {
+		return nil, fmt.Errorf("unable to parse extras for operation %v: %w", operation.OID, err)
+	}
+	flashcard.Review(operation.Timestamp, &review)
+	return flashcard, nil
+}
+
+/*
+ * Add/Delete an annotation on a note
+ */
+
+func AddAnnotation(obj StatefulObject, operation *Operation) (StatefulObject, error) {
+	note, ok := obj.(*Note)
+	if !ok {
+		return nil, fmt.Errorf("object %q is not a note", obj.UniqueOID())
+	}
+	var annotation Annotation
+	if err := operation.parseExtras("annotation", &annotation); err != nil {
+		return nil, fmt.Errorf("unable to parse extras for operation %v: %w", operation.OID, err)
+	}
+	note.AddAnnotation(operation.Timestamp, annotation)
+	return note, nil
+
+}
+
+func RemoveAnnotation(obj StatefulObject, operation *Operation) (StatefulObject, error) {
+	note, ok := obj.(*Note)
+	if !ok {
+		return nil, fmt.Errorf("object %q is not a note", obj.UniqueOID())
+	}
+	var annotation Annotation
+	if err := operation.parseExtras("annotation", &annotation); err != nil {
+		return nil, fmt.Errorf("unable to parse extras for operation %v: %w", operation.OID, err)
+	}
+	note.RemoveAnnotation(operation.Timestamp, annotation)
+	return note, nil
+}
+
+/*
+ * Completed a reminder
+ */
+
+func CompleteReminder(obj StatefulObject, operation *Operation) (StatefulObject, error) {
+	reminder, ok := obj.(*Reminder)
+	if !ok {
+		return nil, fmt.Errorf("object %q is not a reminder", obj.UniqueOID())
+	}
+	reminder.Complete(operation.Timestamp)
+	return reminder, nil
+}
+
+/* Pack File Management */
+
+// NewPackFileFromOperations creates a new pack file from the given operations.
+func NewPackFileFromOperations(operations []*Operation) (*PackFile, error) {
+	packFile := &PackFile{
+		OID: oid.New(),
+		// Init pack file properties
+		CTime: clock.Now(),
+	}
+
+	// Create objects
+	for _, operation := range operations {
+		if err := packFile.AppendPackable(operation); err != nil {
+			return nil, err
+		}
+	}
+
+	// Save the pack file on disk
+	if err := packFile.Save(); err != nil {
+		return nil, err
+	}
+
+	return packFile, nil
+}

--- a/internal/core/operations_test.go
+++ b/internal/core/operations_test.go
@@ -1,0 +1,231 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/julien-sobczak/the-notewriter/pkg/clock"
+	"github.com/julien-sobczak/the-notewriter/pkg/oid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewOperations(t *testing.T) {
+
+	t.Run("MarkNote", func(t *testing.T) {
+		oid := oid.OID("42d74d967d9b4e989502647ac510777ca1e22f4a")
+		op := NewOperationMarkNote(oid)
+
+		assert.Equal(t, oid, op.ObjectOID)
+		assert.Equal(t, "mark-note", op.Name)
+		assert.WithinDuration(t, clock.Now(), op.Timestamp, time.Second)
+	})
+
+	t.Run("UnmarkNote", func(t *testing.T) {
+		oid := oid.OID("42d74d967d9b4e989502647ac510777ca1e22f4a")
+		op := NewOperationUnmarkNote(oid)
+
+		assert.Equal(t, oid, op.ObjectOID)
+		assert.Equal(t, "unmark-note", op.Name)
+		assert.WithinDuration(t, clock.Now(), op.Timestamp, time.Second)
+	})
+
+	t.Run("AddAnnotation", func(t *testing.T) {
+		oid := oid.OID("42d74d967d9b4e989502647ac510777ca1e22f4a")
+		annotation := Annotation{
+			OID:  "f97ba6134cb447f88ae831ff745cf259ebe7d9ad",
+			Text: "Use Markdown emphasis",
+		}
+		op := NewOperationAddAnnotation(oid, annotation)
+
+		assert.Equal(t, oid, op.ObjectOID)
+		assert.Equal(t, "add-annotation", op.Name)
+		assert.WithinDuration(t, clock.Now(), op.Timestamp, time.Second)
+		assert.Contains(t, op.Extras, "annotation")
+		assert.IsType(t, Annotation{}, op.Extras["annotation"])
+	})
+
+	t.Run("RemoveAnnotation", func(t *testing.T) {
+		oid := oid.OID("42d74d967d9b4e989502647ac510777ca1e22f4a")
+		annotation := Annotation{
+			OID: "f97ba6134cb447f88ae831ff745cf259ebe7d9ad",
+		}
+		op := NewOperationRemoveAnnotation(oid, annotation)
+
+		assert.Equal(t, oid, op.ObjectOID)
+		assert.Equal(t, "remove-annotation", op.Name)
+		assert.WithinDuration(t, clock.Now(), op.Timestamp, time.Second)
+		assert.Contains(t, op.Extras, "annotation")
+		assert.IsType(t, Annotation{}, op.Extras["annotation"])
+	})
+
+	t.Run("CompleteReminder", func(t *testing.T) {
+		oid := oid.OID("42d74d967d9b4e989502647ac510777ca1e22f4a")
+		op := NewOperationCompleteReminder(oid)
+
+		assert.Equal(t, oid, op.ObjectOID)
+		assert.Equal(t, "complete-reminder", op.Name)
+		assert.WithinDuration(t, clock.Now(), op.Timestamp, time.Second)
+	})
+
+	t.Run("ReviewFlashcard", func(t *testing.T) {
+		oid := oid.OID("42d74d967d9b4e989502647ac510777ca1e22f4a")
+		review := FlashcardReview{
+			Feedback: "Good",
+			Duration: 500 * time.Millisecond,
+			DueAt:    clock.Now().Add(24 * time.Hour),
+			Settings: map[string]any{
+				"easeFactor": 2500,
+			},
+		}
+		op := NewOperationReviewFlashcard(oid, review)
+
+		assert.Equal(t, oid, op.ObjectOID)
+		assert.Equal(t, "review-flashcard", op.Name)
+		assert.WithinDuration(t, clock.Now(), op.Timestamp, time.Second)
+		assert.Contains(t, op.Extras, "review")
+		assert.IsType(t, FlashcardReview{}, op.Extras["review"])
+	})
+}
+
+func TestNewPackFileFromOperations(t *testing.T) {
+	SetUpRepositoryFromTempDir(t)
+	FreezeOn(t, "2024-01-01 00:00:00")
+
+	// Create a pack file with the different available operations
+	packFile, err := NewPackFileFromOperations([]*Operation{
+		NewOperationMarkNote("42d74d967d9b4e989502647ac510777ca1e22f4a"),
+		NewOperationUnmarkNote("59235bca0a024d1ca46e0b5788e311c71d3e027e"),
+		NewOperationAddAnnotation("40f5c217c3ca4a4f856638901b26a6025bb0b22b", Annotation{
+			OID:  "f97ba6134cb447f88ae831ff745cf259ebe7d9ad",
+			Text: "Use Markdown emphasis",
+		}),
+		NewOperationRemoveAnnotation("40f5c217c3ca4a4f856638901b26a6025bb0b22b", Annotation{
+			OID: "f97ba6134cb447f88ae831ff745cf259ebe7d9ad",
+		}),
+		NewOperationReviewFlashcard("a0e9d4bc5cf64cb2b96a489b5a1ade36d0bd8d44", FlashcardReview{
+			Feedback: "Good",
+			Duration: 500 * time.Millisecond,
+			DueAt:    clock.Now().Add(24 * time.Hour),
+			Settings: map[string]any{
+				"easeFactor": 2500,
+			},
+		}),
+	})
+	require.NoError(t, err)
+	assert.FileExists(t, packFile.ObjectPath())
+
+	// Add the pack file to the current index
+	CurrentIndex().Add(packFile)
+
+	// Reread the pack file to ensure it was written correctly
+	packFile, err = CurrentIndex().ReadPackFile(packFile.OID)
+	require.NoError(t, err)
+	require.NotNil(t, packFile)
+	require.Len(t, packFile.PackObjects, 5)
+
+	// Check the first operation
+	packOperation := packFile.PackObjects[0]
+	assert.Equal(t, "operation", packOperation.Kind)
+	assert.Equal(t, "2024-01-01T00:00:00Z", packOperation.CTime.Format(time.RFC3339))
+	operation := packOperation.Read().(*Operation)
+	assert.Equal(t, "mark-note", operation.Name)
+	assert.Equal(t, oid.OID("42d74d967d9b4e989502647ac510777ca1e22f4a"), operation.ObjectOID)
+	assert.WithinDuration(t, clock.Now(), operation.Timestamp, time.Second)
+}
+
+func TestOperationApply(t *testing.T) {
+	SetUpRepositoryFromTempDir(t)
+	FreezeOn(t, "2024-01-01 00:00:00")
+
+	// Insert the note
+	MustWriteFile(t, "python.md", `# Python
+
+## Flashcard: Python's creator
+
+Who invented Python?
+
+---
+
+Guido van Rossum
+`)
+
+	err := CurrentRepository().Add(PathSpecs{"python.md"})
+	require.NoError(t, err)
+	err = CurrentRepository().Commit()
+	require.NoError(t, err)
+
+	// Check the note is present
+	note := MustFindNoteByTitle(t, "Flashcard: Python's creator")
+	assert.False(t, note.Marked)
+
+	// Create a pack file with operations on this note
+	packFile, err := NewPackFileFromOperations([]*Operation{
+		NewOperationMarkNote(note.OID),
+		NewOperationAddAnnotation(note.OID, Annotation{
+			OID:  "42d74d967d9b4e989502647ac510777ca1e22f4a",
+			Text: "Add reverse card",
+		}),
+	})
+	require.NoError(t, err)
+	assert.FileExists(t, packFile.ObjectPath())
+
+	// Add the pack file in DB
+	CurrentDB().UpsertPackFiles(packFile)
+
+	// Reread the note
+	note = MustFindNoteByTitle(t, "Flashcard: Python's creator")
+	assert.True(t, note.Marked)
+	assert.Equal(t, oid.MustParse("42d74d967d9b4e989502647ac510777ca1e22f4a"), note.Annotations[0].OID)
+
+	// Edit the flashcard without changing the slug so that the existing note is updated
+	MustWriteFile(t, "python.md", `# Python
+
+## Flashcard: Python's creator
+
+Who invented **Python**?
+
+---
+
+Guido van Rossum
+`)
+	note = MustFindNoteByTitle(t, "Flashcard: Python's creator")
+	// Operation-relation fields must be preserved
+	assert.True(t, note.Marked)
+	assert.Equal(t, oid.MustParse("42d74d967d9b4e989502647ac510777ca1e22f4a"), note.Annotations[0].OID)
+
+}
+
+// Learning tests experimenting with package yaml.v3
+func TestYAML(t *testing.T) {
+
+	t.Run("Extra fields", func(t *testing.T) {
+
+		var data = []byte(`
+oid: 94a3f7eedf3d4963926d267c1e114bd14f65123a
+created_at: 2024-01-01T00:00:00Z
+extra_field: hello
+another_field: 42
+`)
+
+		type MyStruct struct {
+			OID   oid.OID        `yaml:"oid"`
+			Extra map[string]any `yaml:",inline"`
+		}
+
+		var s MyStruct
+		err := yaml.Unmarshal(data, &s)
+		require.NoError(t, err)
+
+		assert.Equal(t, oid.OID("94a3f7eedf3d4963926d267c1e114bd14f65123a"), s.OID)
+		// Fields not present in the struct are stored in the Extra map
+		assert.Equal(t, "hello", s.Extra["extra_field"])
+		assert.Equal(t, 42, s.Extra["another_field"])
+
+		// Write back to YAML to ensure extra fields are preserved
+		data, err = yaml.Marshal(s)
+		require.NoError(t, err)
+		assert.Equal(t, "oid: 94a3f7eedf3d4963926d267c1e114bd14f65123a\nanother_field: 42\ncreated_at: 2024-01-01T00:00:00Z\nextra_field: hello\n", string(data))
+	})
+}

--- a/internal/core/packfile.go
+++ b/internal/core/packfile.go
@@ -19,6 +19,27 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+/* Packable */
+
+// Packable represents an object that can be packed into a pack file.
+type Packable interface {
+	// Kind returns the object kind to determine which kind of object to create.
+	Kind() string
+	// UniqueOID returns the OID of the object.
+	UniqueOID() oid.OID
+
+	// Read rereads the object from YAML.
+	Read(r io.Reader) error
+	// Write writes the object to YAML.
+	Write(w io.Writer) error
+
+	// ModificationTime returns the last modification time.
+	ModificationTime() time.Time // TODO rename to Timestamp()
+
+	// String returns a one-line description
+	String() string
+}
+
 /*
  * ObjectData
  */
@@ -27,9 +48,9 @@ import (
 type ObjectData []byte // alias to serialize to YAML easily
 
 // NewObjectData creates a compressed-string representation of the object.
-func NewObjectData(obj Object) (ObjectData, error) {
+func NewObjectData(packable Packable) (ObjectData, error) {
 	b := new(bytes.Buffer)
-	if err := obj.Write(b); err != nil {
+	if err := packable.Write(b); err != nil {
 		return nil, err
 	}
 	in := b.Bytes()
@@ -96,6 +117,10 @@ func (od ObjectData) Unmarshal(target interface{}) error {
 		r.Read(dest)
 		return nil
 	}
+	if r, ok := target.(*Operation); ok {
+		r.Read(dest)
+		return nil
+	}
 
 	return fmt.Errorf("unsupported type %T", target)
 }
@@ -116,13 +141,16 @@ var NilPackFile = &PackFile{
 }
 
 type PackFile struct {
-	OID              oid.OID       `yaml:"oid" json:"oid"`
-	FileRelativePath string        `yaml:"file_relative_path" json:"file_relative_path"`
-	FileMTime        time.Time     `yaml:"file_mtime" json:"file_mtime"`
-	FileSize         int64         `yaml:"file_size" json:"file_size"`
-	CTime            time.Time     `yaml:"ctime" json:"ctime"`
-	PackObjects      []*PackObject `yaml:"objects" json:"objects"`
-	BlobRefs         []*BlobRef    `yaml:"blobs" json:"blobs"`
+	OID oid.OID `yaml:"oid" json:"oid"`
+
+	// File attributes for pack files created from files inside the repository (empty for operations)
+	FileRelativePath string    `yaml:"file_relative_path" json:"file_relative_path"`
+	FileMTime        time.Time `yaml:"file_mtime" json:"file_mtime"`
+	FileSize         int64     `yaml:"file_size" json:"file_size"`
+
+	CTime       time.Time     `yaml:"ctime" json:"ctime"`
+	PackObjects []*PackObject `yaml:"objects" json:"objects"`
+	BlobRefs    []*BlobRef    `yaml:"blobs" json:"blobs"`
 }
 
 type PackObject struct {
@@ -133,8 +161,8 @@ type PackObject struct {
 	Data        ObjectData `yaml:"data" json:"data"`
 }
 
-// ReadObject recreates the core object from a commit object.
-func (p *PackObject) ReadObject() Object {
+// Read recreates the underlying packed struct.
+func (p *PackObject) Read() Packable {
 	switch p.Kind {
 	case "file":
 		file := new(File)
@@ -164,6 +192,10 @@ func (p *PackObject) ReadObject() Object {
 		reminder := new(Reminder)
 		p.Data.Unmarshal(reminder)
 		return reminder
+	case "operation":
+		operation := new(Operation)
+		p.Data.Unmarshal(operation)
+		return operation
 	}
 	return nil
 }
@@ -202,32 +234,32 @@ func (p *PackFile) GetPackObject(oid oid.OID) (*PackObject, bool) {
 	return nil, false
 }
 
-// AppendPackObject registers a new object inside the pack file.
-func (p *PackFile) AppendPackObject(obj *PackObject) {
-	p.PackObjects = append(p.PackObjects, obj)
-}
-
-// MustAppendObject registers a new object inside the pack file or panic.
-func (p *PackFile) MustAppendObject(obj Object) {
-	if err := p.AppendObject(obj); err != nil {
+// MustAppendPackable registers a new object inside the pack file or panic.
+func (p *PackFile) MustAppendPackable(packable Packable) {
+	if err := p.AppendPackable(packable); err != nil {
 		panic(err)
 	}
 }
 
-// AppendObject registers a new object inside the pack file.
-func (p *PackFile) AppendObject(obj Object) error {
-	data, err := NewObjectData(obj)
+// AppendPackable registers a new packable inside the pack file.
+func (p *PackFile) AppendPackable(packable Packable) error {
+	data, err := NewObjectData(packable)
 	if err != nil {
 		return err
 	}
 	p.PackObjects = append(p.PackObjects, &PackObject{
-		OID:         obj.UniqueOID(),
-		Kind:        obj.Kind(),
-		CTime:       obj.ModificationTime(),
-		Description: obj.String(),
+		OID:         packable.UniqueOID(),
+		Kind:        packable.Kind(),
+		CTime:       packable.ModificationTime(),
+		Description: packable.String(),
 		Data:        data,
 	})
 	return nil
+}
+
+// AppendPackObject registers a new object inside the pack file.
+func (p *PackFile) AppendPackObject(obj *PackObject) {
+	p.PackObjects = append(p.PackObjects, obj)
 }
 
 // AppendBlob registers a new blob inside the pack file.
@@ -292,7 +324,11 @@ func (p *PackFile) Save() error {
 	if CurrentConfig().DryRun {
 		return nil
 	}
-	return p.SaveTo(PackFilePath(p.OID))
+	if err := p.SaveTo(PackFilePath(p.OID)); err != nil {
+		return fmt.Errorf("unable to save pack file %s: %w", p.OID, err)
+	}
+	CurrentLogger().Infof("💾 Saved pack file %s", filepath.Base(p.ObjectPath()))
+	return nil
 }
 
 // ObjectPath returns the absolute path to the pack file in .nt/objects/ directory.
@@ -312,7 +348,7 @@ func PackFilePath(oid oid.OID) string {
 
 // PackFileRelativePath returns the path to the pack file in .nt/objects/ directory.
 func PackFileRelativePath(oid oid.OID) string {
-	return "objects/" + oid.RelativePath(".pack")
+	return "objects/" + oid.RelativePath(".pack") // Ex: objects/94/94....pack
 }
 
 // SaveTo writes a new pack file to the given location.
@@ -476,7 +512,7 @@ func (p *PackFile) Diff(other *PackFile) ObjectDiffs {
 	var result ObjectDiffs
 
 	for _, beforePackObject := range p.PackObjects {
-		beforeObject := beforePackObject.ReadObject()
+		beforeObject := beforePackObject.Read()
 		beforeParsedObject, ok := beforeObject.(ParsedObject)
 		if !ok {
 			// We diff only objects extracted from Markdown files
@@ -489,7 +525,7 @@ func (p *PackFile) Diff(other *PackFile) ObjectDiffs {
 				continue
 			}
 
-			afterObject := afterPackObject.ReadObject()
+			afterObject := afterPackObject.Read()
 			if afterParsedObject, ok := afterObject.(ParsedObject); ok {
 				// Compare both
 				result = append(result, &ObjectDiff{
@@ -512,7 +548,7 @@ func (p *PackFile) Diff(other *PackFile) ObjectDiffs {
 			continue
 		}
 
-		afterObject := afterPackObject.ReadObject()
+		afterObject := afterPackObject.Read()
 		if afterParsedObject, ok := afterObject.(ParsedObject); ok {
 			// Added
 			result = append(result, &ObjectDiff{

--- a/internal/core/packfile_test.go
+++ b/internal/core/packfile_test.go
@@ -294,7 +294,7 @@ objects:
       kind: reminder
       ctime: 2023-01-01T12:30:00Z
       desc: 'reminder #reminder-2023-06-26 [8000000000000000000000000000000000000000]'
-      data: eJyMjr1urDAQhXs/hcUtuClYjJdf91FeIFWiCBl7DFbAtswQ7eNHIVptkmLF6HTzfWfGWy1o0rJjk5Ag1buxM/S7WKqqaaHiTWeagYHUpuKqMKaCtuz4oIdOlrw2QG5KUhy+5TxepeawFGGWaD+gDxInQUd/WjTRsKpoA1rvBE1fn3yYICrv6OMWfYC3/xNiWEWej9fNCbb8ISUoR0HTfxEW6zTEjDN+zlid8Tols1yxDxCNjwvoXqKgjLEi2/PMmNjzQhxc/nK3mh+ciiDxF7AXFVycv4Et6PvA14+Xe8BnAAAA///TlIXH
+      data: eJyMzb9OwzAQBvDdT2GFITCksd389Y54ASYQihzfObFobcu9IB4fAaq6Vbnx7vvdFz1oXgxi3xQsGfvp/AmnP9jYth+wVf3o+lmgAdcqK51rcWhGNcM8mkZ1DtmNFHJ3V4h0Rf1ulPFkyH/hlAytmi/xcAYGeLHZJ/IxaF6+v8S0YrYx8Octx4QfjytRuui6Xq6XA271U8nILJqXDxnPPgDmSgl1rERXqa5kNqMhhMmQ5v97WQn5KpU+Ci3EG9sS3A/8/vy+F/gJAAD//2OZbo4=
 blobs:
     - oid: "2000000000000000000000000000000000000000"
       mime: text/markdown

--- a/internal/core/reminder.go
+++ b/internal/core/reminder.go
@@ -41,8 +41,8 @@ type Reminder struct {
 	Tag string `yaml:"tag" json:"tag"`
 
 	// Timestamps to track progress
-	LastPerformedAt time.Time `yaml:"last_performed_at" json:"last_performed_at"`
-	NextPerformedAt time.Time `yaml:"next_performed_at" json:"next_performed_at"`
+	LastPerformedAt time.Time `yaml:"-" json:"-"`
+	NextPerformedAt time.Time `yaml:"-" json:"-"`
 
 	// Timestamps to track changes
 	CreatedAt time.Time `yaml:"created_at" json:"created_at"`
@@ -168,21 +168,28 @@ func (r *Reminder) update(packFile *PackFile, note *Note, parsedReminder *Parsed
 
 /* State Management */
 
+func (r *Reminder) Expression() string {
+	return strings.TrimPrefix(r.Tag, "#reminder-")
+}
+
 func (r *Reminder) Next() error {
-	if clock.Now().Before(r.NextPerformedAt) {
-		// already OK
+	// Determine the timestamp of reference
+	lastPerformedAt := clock.Now()
+	if !r.LastPerformedAt.IsZero() {
+		lastPerformedAt = r.LastPerformedAt
+	}
+
+	// Next date already calculated?
+	if lastPerformedAt.Before(r.NextPerformedAt) {
 		return nil
 	}
 
-	expression := strings.TrimPrefix(r.Tag, "#reminder-")
-
-	lastPerformedAt := r.NextPerformedAt
-	nextPerformedAt, err := EvaluateTimeExpression(expression)
+	nextPerformedAt, err := EvaluateTimeExpressionAfter(r.LastPerformedAt, r.Expression())
 	if err != nil {
 		return err
 	}
-	r.LastPerformedAt = lastPerformedAt
 	r.NextPerformedAt = nextPerformedAt
+
 	return nil
 }
 
@@ -208,10 +215,14 @@ func (r *Reminder) ToMarkdown() string {
 
 /* Parsing */
 
-// EvaluateTimeExpression determine the next matching reminder date
+// EvaluateTimeExpression determine the next matching reminder date after the current time.
 func EvaluateTimeExpression(expr string) (time.Time, error) {
+	return EvaluateTimeExpressionAfter(clock.Now(), expr)
+}
+
+// EvaluateTimeExpressionAfter determine the next matching reminder date after the given timestamp.
+func EvaluateTimeExpressionAfter(timestamp time.Time, expr string) (time.Time, error) {
 	originalExpr := expr
-	today := clock.Now()
 
 	// Static dates are easier to address first
 	var reStaticDate = regexp.MustCompile(`(\d{4})(?:-(\d{2})(?:-(\d{2})))`)
@@ -227,10 +238,10 @@ func EvaluateTimeExpression(expr string) (time.Time, error) {
 			day, _ = strconv.Atoi(dayStr)
 		}
 		if monthStr == "" {
-			if day < today.Day() {
-				month = int(today.Month()) + 1
+			if day < timestamp.Day() {
+				month = int(timestamp.Month()) + 1
 			} else {
-				month = int(today.Month())
+				month = int(timestamp.Month())
 			}
 		} else {
 			month, _ = strconv.Atoi(monthStr)
@@ -355,12 +366,12 @@ func EvaluateTimeExpression(expr string) (time.Time, error) {
 	}
 
 	// Generate all possible combinations
-	possibleDates := generateDates(yearExpr, monthExpr, dayExpr)
+	possibleDates := generateDates(timestamp, yearExpr, monthExpr, dayExpr)
 
 	// Filter to keep only future dates
 	var possibleFutureDates []time.Time
 	for _, possibleDate := range possibleDates {
-		if possibleDate.After(today) {
+		if possibleDate.After(timestamp) {
 			possibleFutureDates = append(possibleFutureDates, possibleDate)
 		}
 	}
@@ -378,7 +389,7 @@ func EvaluateTimeExpression(expr string) (time.Time, error) {
 	return possibleFutureDates[0], nil
 }
 
-func generateDates(yearExpr, monthExpr, dayExpr string) []time.Time {
+func generateDates(timestamp time.Time, yearExpr, monthExpr, dayExpr string) []time.Time {
 	// Implementation: We generate all potential candidate dates as it's not easy to determine the target value.
 	//
 	// Ex: `reminder-${year}-07-02`
@@ -398,7 +409,6 @@ func generateDates(yearExpr, monthExpr, dayExpr string) []time.Time {
 		return []time.Time{time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)}
 	}
 
-	today := clock.Now()
 	var dates []time.Time
 	if !text.IsNumber(yearExpr) {
 		switch yearExpr {
@@ -406,23 +416,23 @@ func generateDates(yearExpr, monthExpr, dayExpr string) []time.Time {
 			fallthrough
 		case "year":
 			// this year or next year
-			dates = append(dates, generateDates(fmt.Sprint(today.Year()), monthExpr, dayExpr)...)
-			dates = append(dates, generateDates(fmt.Sprint(today.Year()+1), monthExpr, dayExpr)...)
+			dates = append(dates, generateDates(timestamp, fmt.Sprint(timestamp.Year()), monthExpr, dayExpr)...)
+			dates = append(dates, generateDates(timestamp, fmt.Sprint(timestamp.Year()+1), monthExpr, dayExpr)...)
 			return dates
 		case "odd-year":
-			if today.Year()%2 == 0 {
-				dates = append(dates, generateDates(fmt.Sprint(today.Year()), monthExpr, dayExpr)...)
-				dates = append(dates, generateDates(fmt.Sprint(today.Year()+2), monthExpr, dayExpr)...)
+			if timestamp.Year()%2 == 0 {
+				dates = append(dates, generateDates(timestamp, fmt.Sprint(timestamp.Year()), monthExpr, dayExpr)...)
+				dates = append(dates, generateDates(timestamp, fmt.Sprint(timestamp.Year()+2), monthExpr, dayExpr)...)
 			} else {
-				dates = append(dates, generateDates(fmt.Sprint(today.Year()+1), monthExpr, dayExpr)...)
+				dates = append(dates, generateDates(timestamp, fmt.Sprint(timestamp.Year()+1), monthExpr, dayExpr)...)
 			}
 			return dates
 		case "even-year":
-			if today.Year()%2 == 1 {
-				dates = append(dates, generateDates(fmt.Sprint(today.Year()), monthExpr, dayExpr)...)
-				dates = append(dates, generateDates(fmt.Sprint(today.Year()+2), monthExpr, dayExpr)...)
+			if timestamp.Year()%2 == 1 {
+				dates = append(dates, generateDates(timestamp, fmt.Sprint(timestamp.Year()), monthExpr, dayExpr)...)
+				dates = append(dates, generateDates(timestamp, fmt.Sprint(timestamp.Year()+2), monthExpr, dayExpr)...)
 			} else {
-				dates = append(dates, generateDates(fmt.Sprint(today.Year()+1), monthExpr, dayExpr)...)
+				dates = append(dates, generateDates(timestamp, fmt.Sprint(timestamp.Year()+1), monthExpr, dayExpr)...)
 			}
 			return dates
 		default:
@@ -437,59 +447,59 @@ func generateDates(yearExpr, monthExpr, dayExpr string) []time.Time {
 		case "":
 			fallthrough
 		case "month":
-			if today.Year() == year {
+			if timestamp.Year() == year {
 				// this month + next month
-				dates = append(dates, generateDates(yearExpr, fmt.Sprintf("%02d", today.Month()), dayExpr)...)
-				if today.Month() == time.December {
-					dates = append(dates, generateDates(yearExpr, "01", dayExpr)...)
+				dates = append(dates, generateDates(timestamp, yearExpr, fmt.Sprintf("%02d", timestamp.Month()), dayExpr)...)
+				if timestamp.Month() == time.December {
+					dates = append(dates, generateDates(timestamp, yearExpr, "01", dayExpr)...)
 				} else {
-					dates = append(dates, generateDates(yearExpr, fmt.Sprintf("%02d", today.Month()+1), dayExpr)...)
+					dates = append(dates, generateDates(timestamp, yearExpr, fmt.Sprintf("%02d", timestamp.Month()+1), dayExpr)...)
 				}
 			} else {
 				// First month of a future year
-				dates = append(dates, generateDates(yearExpr, "01", dayExpr)...)
+				dates = append(dates, generateDates(timestamp, yearExpr, "01", dayExpr)...)
 			}
 			return dates
 		case "odd-month":
-			if today.Year() == year {
-				if today.Month()%2 == 0 {
+			if timestamp.Year() == year {
+				if timestamp.Month()%2 == 0 {
 					// this month + next odd month
-					dates = append(dates, generateDates(yearExpr, fmt.Sprintf("%02d", today.Month()), dayExpr)...)
-					if today.Month() == time.December {
-						dates = append(dates, generateDates(yearExpr, "02", dayExpr)...)
+					dates = append(dates, generateDates(timestamp, yearExpr, fmt.Sprintf("%02d", timestamp.Month()), dayExpr)...)
+					if timestamp.Month() == time.December {
+						dates = append(dates, generateDates(timestamp, yearExpr, "02", dayExpr)...)
 					} else {
-						dates = append(dates, generateDates(yearExpr, fmt.Sprintf("%02d", today.Month()+2), dayExpr)...)
+						dates = append(dates, generateDates(timestamp, yearExpr, fmt.Sprintf("%02d", timestamp.Month()+2), dayExpr)...)
 					}
 				} else {
 					// next month (NB: +1 is safe as we know the current month is even)
-					dates = append(dates, generateDates(yearExpr, fmt.Sprintf("%02d", today.Month()+1), dayExpr)...)
+					dates = append(dates, generateDates(timestamp, yearExpr, fmt.Sprintf("%02d", timestamp.Month()+1), dayExpr)...)
 				}
 			} else {
 				// First odd month of a future year
-				dates = append(dates, generateDates(yearExpr, "02", dayExpr)...)
+				dates = append(dates, generateDates(timestamp, yearExpr, "02", dayExpr)...)
 			}
 			return dates
 		case "even-month":
-			if today.Year() == year {
-				if today.Month()%2 == 1 {
+			if timestamp.Year() == year {
+				if timestamp.Month()%2 == 1 {
 					// this month + next even month
-					dates = append(dates, generateDates(yearExpr, fmt.Sprintf("%02d", today.Month()), dayExpr)...)
-					if today.Month() == time.November {
-						dates = append(dates, generateDates(yearExpr, "01", dayExpr)...)
+					dates = append(dates, generateDates(timestamp, yearExpr, fmt.Sprintf("%02d", timestamp.Month()), dayExpr)...)
+					if timestamp.Month() == time.November {
+						dates = append(dates, generateDates(timestamp, yearExpr, "01", dayExpr)...)
 					} else {
-						dates = append(dates, generateDates(yearExpr, fmt.Sprintf("%02d", today.Month()+2), dayExpr)...)
+						dates = append(dates, generateDates(timestamp, yearExpr, fmt.Sprintf("%02d", timestamp.Month()+2), dayExpr)...)
 					}
 				} else {
 					// next month
-					if today.Month() == time.December {
-						dates = append(dates, generateDates(yearExpr, "01", dayExpr)...)
+					if timestamp.Month() == time.December {
+						dates = append(dates, generateDates(timestamp, yearExpr, "01", dayExpr)...)
 					} else {
-						dates = append(dates, generateDates(yearExpr, fmt.Sprintf("%02d", today.Month()+1), dayExpr)...)
+						dates = append(dates, generateDates(timestamp, yearExpr, fmt.Sprintf("%02d", timestamp.Month()+1), dayExpr)...)
 					}
 				}
 			} else {
 				// First even month of a future year
-				dates = append(dates, generateDates(yearExpr, "01", dayExpr)...)
+				dates = append(dates, generateDates(timestamp, yearExpr, "01", dayExpr)...)
 			}
 			return dates
 		default:
@@ -506,11 +516,11 @@ func generateDates(yearExpr, monthExpr, dayExpr string) []time.Time {
 	case "":
 		fallthrough
 	case "day":
-		if today.Year() == year && today.Month() == time.Month(month) {
-			dates = append(dates, generateDates(yearExpr, monthExpr, fmt.Sprintf("%02d", today.Day()+1))...)
-			dates = append(dates, generateDates(yearExpr, monthExpr, "01")...) // end of month
+		if timestamp.Year() == year && timestamp.Month() == time.Month(month) {
+			dates = append(dates, generateDates(timestamp, yearExpr, monthExpr, fmt.Sprintf("%02d", timestamp.Day()+1))...)
+			dates = append(dates, generateDates(timestamp, yearExpr, monthExpr, "01")...) // end of month
 		} else {
-			dates = append(dates, generateDates(yearExpr, monthExpr, "01")...)
+			dates = append(dates, generateDates(timestamp, yearExpr, monthExpr, "01")...)
 		}
 		return dates
 	case "monday":
@@ -641,6 +651,11 @@ func (r *Reminder) Save() error {
 	return nil
 }
 
+func (r *Reminder) SaveMetadata() error {
+	// No operation-related fields for now
+	return nil
+}
+
 func (r *Reminder) Delete() error {
 	CurrentLogger().Debugf("Deleting reminder %s...", r.Description)
 	query := `DELETE FROM reminder WHERE oid = ? AND packfile_oid = ?;`
@@ -667,23 +682,8 @@ func (r *Repository) FindMatchingReminder(note *Note, parsedReminder *ParsedRemi
 	return QueryReminder(CurrentDB().Client(), `WHERE note_oid = ? and description = ?`, note.OID, parsedReminder.Description)
 }
 
-func (r *Repository) FindMatchingReminders(noteOID oid.OID, descriptionRaw string) ([]*Reminder, error) {
-	return QueryReminders(CurrentDB().Client(), `WHERE note_oid = ? and description = ?`, noteOID, descriptionRaw)
-}
-
 func (r *Repository) LoadReminderByOID(oid oid.OID) (*Reminder, error) {
 	return QueryReminder(CurrentDB().Client(), `WHERE oid = ?`, oid)
-}
-
-func (r *Repository) FindRemindersByUpcomingDate(deadline time.Time) ([]*Reminder, error) {
-	return QueryReminders(CurrentDB().Client(), `WHERE next_performed_at > ?`, timeToSQL(deadline))
-}
-
-func (r *Repository) FindRemindersLastCheckedBefore(point time.Time, path string) ([]*Reminder, error) {
-	if path == "." {
-		path = ""
-	}
-	return QueryReminders(CurrentDB().Client(), `WHERE indexed_at < ? AND relative_path LIKE ?`, timeToSQL(point), path+"%")
 }
 
 /* SQL Helpers */
@@ -805,4 +805,17 @@ func QueryReminders(db SQLClient, whereClause string, args ...any) ([]*Reminder,
 	}
 
 	return reminders, err
+}
+
+/*
+ * Operations
+ */
+
+func (r *Reminder) Complete(timestamp time.Time) error {
+	if !r.LastPerformedAt.IsZero() && r.LastPerformedAt.After(timestamp) {
+		// Ignore if the reminder was already completed
+		return nil
+	}
+	r.LastPerformedAt = timestamp
+	return r.Next()
 }

--- a/internal/core/reminder_test.go
+++ b/internal/core/reminder_test.go
@@ -101,8 +101,6 @@ note_oid: 52d02a28a961471db62c6d40d30639dafe4aba00
 relative_path: project.md
 description: Test
 tag: '#reminder-2085-09'
-last_performed_at: 0001-01-01T00:00:00Z
-next_performed_at: 2085-09-01T00:00:00Z
 created_at: 2023-01-01T01:12:30Z
 updated_at: 2023-01-01T01:12:30Z
 indexed_at: 2023-01-01T01:12:30Z
@@ -121,8 +119,6 @@ indexed_at: 2023-01-01T01:12:30Z
   "relative_path": "project.md",
   "description": "Test",
   "tag": "#reminder-2085-09",
-  "last_performed_at": "0001-01-01T00:00:00Z",
-  "next_performed_at": "2085-09-01T00:00:00Z",
   "created_at": "2023-01-01T01:12:30Z",
   "updated_at": "2023-01-01T01:12:30Z",
   "indexed_at": "2023-01-01T01:12:30Z"
@@ -203,4 +199,22 @@ func TestEvaluateTimeExpression(t *testing.T) {
 			assert.EqualValues(t, tt.expected, actual)
 		})
 	}
+}
+
+func TestEvaluateTimeExpressionAfter(t *testing.T) {
+	FreezeOn(t, "2023-07-01 12:30")
+	t.Skip() // FIXME
+
+	expr := "every-2025-${month}"
+	next := HumanTime(t, "2025-01-01 00:00:00")
+
+	// Iteration 1
+	next, err := EvaluateTimeExpressionAfter(next, expr)
+	require.NoError(t, err)
+	assert.EqualValues(t, HumanTime(t, "2025-02-01 00:00:00"), next) // invalid value
+
+	// Iteration 2
+	next, err = EvaluateTimeExpressionAfter(next, expr)
+	require.NoError(t, err)
+	assert.EqualValues(t, HumanTime(t, "2025-03-01 00:00:00"), next) // invalid value
 }

--- a/internal/core/repository.go
+++ b/internal/core/repository.go
@@ -405,11 +405,19 @@ func (r *Repository) Add(paths PathSpecs) error {
 	if err := db.BeginTransaction(); err != nil {
 		return err
 	}
-	db.UpsertPackFiles(packFilesToUpsert...)
-	db.DeletePackFiles(packFilesToDelete...)
+	if err := db.UpsertPackFiles(packFilesToUpsert...); err != nil {
+		return err
+	}
+	if err := db.DeletePackFiles(packFilesToDelete...); err != nil {
+		return err
+	}
 	// TODO Create .bak if Commit fails?
-	db.Index().Stage(packFilesToUpsert...)
-	db.Index().Unstage(packFilesToDelete...)
+	if err := db.Index().Stage(packFilesToUpsert...); err != nil {
+		return err
+	}
+	if err := db.Index().Unstage(packFilesToDelete...); err != nil {
+		return err
+	}
 
 	// Don't forget to commit
 	if err := db.CommitTransaction(); err != nil {

--- a/internal/core/sql/1_init_schema.up.sql
+++ b/internal/core/sql/1_init_schema.up.sql
@@ -86,7 +86,15 @@ CREATE TABLE note (
   -- Timestamps to track changes
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
-  indexed_at TEXT
+  indexed_at TEXT,
+
+  -- Operations
+
+  -- Annotations on the note (JSON document)
+  annotations TEXT CHECK(json_valid(annotations)) DEFAULT '[]',
+  -- Marked the note for further investigation
+  marked INTEGER NOT NULL DEFAULT 0,
+  marked_at TEXT
 );
 
 CREATE VIRTUAL TABLE note_fts USING FTS5(oid UNINDEXED, note_type UNINDEXED, short_title, content, content='note', content_rowid='rowid');

--- a/website/src/content/docs/reference/internals.md
+++ b/website/src/content/docs/reference/internals.md
@@ -248,8 +248,6 @@ relative_path: go.md       # Relative path to the file containing this reminder
 description: |-            # The description of reminder
     '[Gophercon Europe](https://gophercon.eu/)'
 tag: '#reminder-2023-06-26'               # The tag
-last_performed_at: 0001-01-01T00:00:00Z   # Last time when the reminder what planned (for recurring reminder)
-next_performed_at: 2023-06-26T00:00:00Z   # Next time when the reminder is planned (for future reminder)
 created_at: 2023-01-01T12:00:00           # Object creation time
 updated_at: 2023-01-01T12:00:00           # Object modification time
 ```


### PR DESCRIPTION
## Motivations

We want to apply some actions on objects extracted from Markdown files. These actions cannot be described in Markdown. For example:

- Mark a note while using a client application (desktop, mobile) to review a note later.
- Add an annotation on a note (ex: "Delete this note")
- Review a flashcard (ex: new interval = 4 days) <= The main use case that motivates this MR

## Implementation

Use [Conflict-free replicated data type](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type) (CRDT) to apply these operations on objects. These operations are described in YAML:

```yml
- oid: <OID>                         # Unique OID for this operation
  object_oid: <OID>                  # OID of the object on which this operation apply
  name: "add-annotation"             # Keyword naming the operation kind
  created_at: "2025-02-01T12:00:00"  # Timestamp (Last Write Wins strategy is used to resolve conflicts)
  annotation:                        # Extra fields specific to this operation kind
  - oid: <OID> 
    text: "Delete this note"
```

They are then grouped in packfiles (under `.nt/operations`). They will be pushed/pull like any other packfiles.

This MR introduces the logic to store operations in the index. Operations will be actively used in the client applications. The core binary must only be able to pull them and update objects accordingly in the SQL database.