### PR TITLE
fix: initial personal notes import

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,6 @@
 
 ## TODO: Bug Fixes
 
-* [ ] Add linter `no-empty-title` (ex: `## Flashcard: ` is accepted...)
-* [ ] Understand why 900 flashcards in SQLite but 1350 `## Flashcard:` in VS Code 🤔
 * [ ] `nt add .` `nt gc` `nt add .` `nt gc` ... Files are always garbage-collected when nothing must be adding and garbage-collected on second run => Add a unit test
 * [ ] Rework `CastDateFn` to keep the string content (better when exploiting fields later) => Use `type: string` and `format: date` instead and have a list of predefined formats (like `isbn` to check in `CheckAttributes`)
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 
 ## TODO: Bug Fixes
 
-* [ ] Rework `CastDateFn` to keep the string content (better when exploiting fields later) => Use `type: string` and `format: date` instead and have a list of predefined formats (like `isbn` to check in `CheckAttributes`)
+* [ ] TODO
 
 ## TODO: Sprint
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,9 @@
 
 ## TODO: Bug Fixes
 
+* [ ] Add linter `no-empty-title` (ex: `## Flashcard: ` is accepted...)
+* [ ] Understand why 900 flashcards in SQLite but 1350 `## Flashcard:` in VS Code 🤔
+* [ ] `nt add .` `nt gc` `nt add .` `nt gc` ... Files are always garbage-collected when nothing must be adding and garbage-collected on second run => Add a unit test
 * [ ] Rework `CastDateFn` to keep the string content (better when exploiting fields later) => Use `type: string` and `format: date` instead and have a list of predefined formats (like `isbn` to check in `CheckAttributes`)
 
 ## TODO: Sprint

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@
 
 ## TODO: Bug Fixes
 
-* [ ] `nt add .` `nt gc` `nt add .` `nt gc` ... Files are always garbage-collected when nothing must be adding and garbage-collected on second run => Add a unit test
 * [ ] Rework `CastDateFn` to keep the string content (better when exploiting fields later) => Use `type: string` and `format: date` instead and have a list of predefined formats (like `isbn` to check in `CheckAttributes`)
 
 ## TODO: Sprint

--- a/cmd/nt/add.go
+++ b/cmd/nt/add.go
@@ -23,7 +23,7 @@ var addCmd = &cobra.Command{
 
 		CheckConfig()
 
-		err := core.CurrentRepository().Add(argsToPathSpecs(args))
+		_, err := core.CurrentRepository().Add(argsToPathSpecs(args))
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/nt/gc.go
+++ b/cmd/nt/gc.go
@@ -19,7 +19,7 @@ var gcCmd = &cobra.Command{
 	Long:  `Garbage collect unreferenced objects/blobs locally.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckConfig()
-		err := core.CurrentDB().GC(dryRun)
+		_, err := core.CurrentDB().GC(dryRun)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/nt/gc.go
+++ b/cmd/nt/gc.go
@@ -9,6 +9,7 @@ import (
 )
 
 func init() {
+	gcCmd.Flags().BoolVarP(&dryRun, "n", "", false, "no side-effects")
 	rootCmd.AddCommand(gcCmd)
 }
 
@@ -18,12 +19,7 @@ var gcCmd = &cobra.Command{
 	Long:  `Garbage collect unreferenced objects/blobs locally.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckConfig()
-		if core.CurrentDB().Origin() == nil {
-			fmt.Println("There is no remote currently configured.")
-			fmt.Println("Please specify one in .nt/config")
-			os.Exit(1)
-		}
-		err := core.CurrentDB().GC()
+		err := core.CurrentDB().GC(dryRun)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/nt/nt.go
+++ b/cmd/nt/nt.go
@@ -20,6 +20,7 @@ var parallel int
 // Common flags used by multiple commands
 var force bool
 var interactive bool
+var dryRun bool
 
 var rootCmd = &cobra.Command{
 	Use:   "nt",

--- a/internal/core/attributes.go
+++ b/internal/core/attributes.go
@@ -183,48 +183,45 @@ var CastBoolFn CastFn[bool] = func(value any) (bool, bool) {
 	return false, false
 }
 
-var CastDateFn CastFn[time.Time] = func(value any) (time.Time, bool) {
-	// Already the right type?
-	if v, ok := value.(time.Time); ok {
-		return v, true
+var CastDateFn CastFn[string] = func(v any) (string, bool) {
+	// Only convert from string to time.Time
+	if !IsString(v) {
+		return "", false
 	}
 
-	// Only convert from string to time.Time
-	if !IsString(value) {
-		return time.Time{}, false
-	}
+	value := v.(string)
 
 	// YAML uses ISO 8601 format. Try it first
 	// (using a subset RFC as Golang doesn't provide the ISO 8601 format specifically).
 	// See https://symfony.com/doc/current/reference/formats/yaml.html#dates
-	parsedDate, err := time.Parse(time.RFC3339, value.(string)) // Ex: "2023-10-15T14:12:00Z"
+	_, err := time.Parse(time.RFC3339, value) // Ex: "2023-10-15T14:12:00Z"
 	if err == nil {
-		return parsedDate, true
+		return value, true
 	}
 
 	// Try additional common format (more specific to least specific)
 
-	parsedDate, err = time.Parse(time.DateTime, value.(string)) // Ex: "2023-10-15 14:12:00"
+	_, err = time.Parse(time.DateTime, value) // Ex: "2023-10-15 14:12:00"
 	if err == nil {
-		return parsedDate, true
+		return value, true
 	}
 
-	parsedDate, err = time.Parse(time.DateOnly, value.(string)) // Ex: "2023-10-15"
+	_, err = time.Parse(time.DateOnly, value) // Ex: "2023-10-15"
 	if err == nil {
-		return parsedDate, true
+		return value, true
 	}
 
-	parsedDate, err = time.Parse("2006-01", value.(string)) // Ex: "2023-10"
+	_, err = time.Parse("2006-01", value) // Ex: "2023-10"
 	if err == nil {
-		return parsedDate, true
+		return value, true
 	}
 
-	parsedDate, err = time.Parse("2006", value.(string)) // Ex: "2023"
+	_, err = time.Parse("2006", value) // Ex: "2023"
 	if err == nil {
-		return parsedDate, true
+		return value, true
 	}
 
-	return time.Time{}, false
+	return "", false
 }
 
 func NewAttributeSetFromMarkdown(md *markdown.File) (AttributeSet, error) {

--- a/internal/core/attributes_test.go
+++ b/internal/core/attributes_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/julien-sobczak/the-notewriter/internal/markdown"
 	"github.com/stretchr/testify/assert"
@@ -190,37 +189,37 @@ func TestCastFn(t *testing.T) {
 		v, ok := CastDateFn("2024-12-31")
 		assert.True(t, ok)
 		assert.NotZero(t, v)
-		assert.Equal(t, time.Date(2024, time.Month(12), 31, 0, 0, 0, 0, time.UTC), v)
+		assert.Equal(t, "2024-12-31", v)
 
 		// datetimes are OK
 		v, ok = CastDateFn("2024-12-31 12:32:00")
 		assert.True(t, ok)
 		assert.NotZero(t, v)
-		assert.Equal(t, time.Date(2024, time.Month(12), 31, 12, 32, 0, 0, time.UTC), v)
+		assert.Equal(t, "2024-12-31 12:32:00", v)
 
 		// RFC datetimes are OK
 		v, ok = CastDateFn("2024-12-31T12:32:00Z")
 		assert.True(t, ok)
 		assert.NotZero(t, v)
-		assert.Equal(t, time.Date(2024, time.Month(12), 31, 12, 32, 0, 0, time.UTC), v)
+		assert.Equal(t, "2024-12-31T12:32:00Z", v)
 
 		// RFC with a different timezone datetimes are OK
 		v, ok = CastDateFn("2024-12-31T12:32:00-05:00")
 		assert.True(t, ok)
 		assert.NotZero(t, v)
-		assert.Equal(t, time.Date(2024, time.Month(12), 31, 17, 32, 0, 0, time.UTC), v.In(time.UTC))
+		assert.Equal(t, "2024-12-31T12:32:00-05:00", v)
 
 		// Year and month are OK
 		v, ok = CastDateFn("2024-12")
 		assert.True(t, ok)
 		assert.NotZero(t, v)
-		assert.Equal(t, time.Date(2024, time.Month(12), 1, 0, 0, 0, 0, time.UTC), v)
+		assert.Equal(t, "2024-12", v)
 
 		// Year is OK
 		v, ok = CastDateFn("2024")
 		assert.True(t, ok)
 		assert.NotZero(t, v)
-		assert.Equal(t, time.Date(2024, time.Month(1), 1, 0, 0, 0, 0, time.UTC), v)
+		assert.Equal(t, "2024", v)
 	})
 
 }

--- a/internal/core/commands_test.go
+++ b/internal/core/commands_test.go
@@ -68,7 +68,7 @@ func TestCommandAdd(t *testing.T) {
 	t.Run("Basic", func(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestMinimal")
 
-		err := CurrentRepository().Add(PathSpecs{"go.md"})
+		_, err := CurrentRepository().Add(PathSpecs{"go.md"})
 		require.NoError(t, err)
 
 		// Check index file
@@ -105,7 +105,7 @@ func TestCommandAdd(t *testing.T) {
 	t.Run("Add Media", func(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestMedias")
 
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 
 		// Check referenced blobs are present
@@ -151,7 +151,7 @@ func TestCommandAdd(t *testing.T) {
 	t.Run("Repetitive", func(t *testing.T) {
 		root := SetUpRepositoryFromGoldenDirNamed(t, "TestMinimal")
 
-		err := CurrentRepository().Add(PathSpecs{"go.md"})
+		_, err := CurrentRepository().Add(PathSpecs{"go.md"})
 		require.NoError(t, err)
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)
@@ -163,11 +163,11 @@ func TestCommandAdd(t *testing.T) {
 
 		// Check 1: Try to add the same file edited several times
 		ReplaceLine(t, filepath.Join(root, "go.md"), 19, "What does the **Golang logo** represent?", "(Go) What does the **Golang logo** represent?")
-		err = CurrentRepository().Add(PathSpecs{"go.md"})
+		_, err = CurrentRepository().Add(PathSpecs{"go.md"})
 		require.NoError(t, err)
 		// Edit again before the commit
 		ReplaceLine(t, filepath.Join(root, "go.md"), 19, "(Go) What does the **Golang logo** represent?", "(Go) What does the **logo** represent?")
-		err = CurrentRepository().Add(PathSpecs{"go.md"})
+		_, err = CurrentRepository().Add(PathSpecs{"go.md"})
 		require.NoError(t, err)
 
 		err = CurrentRepository().Commit()
@@ -175,12 +175,12 @@ func TestCommandAdd(t *testing.T) {
 
 		// Check 2: Try to commit the same file repeatability
 		ReplaceLine(t, filepath.Join(root, "go.md"), 19, "(Go) What does the **logo** represent?", "What is the **logo**?")
-		err = CurrentRepository().Add(PathSpecs{"go.md"})
+		_, err = CurrentRepository().Add(PathSpecs{"go.md"})
 		require.NoError(t, err)
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)
 		ReplaceLine(t, filepath.Join(root, "go.md"), 19, "What is the **logo**?", "What represents the **logo**?")
-		err = CurrentRepository().Add(PathSpecs{"go.md"})
+		_, err = CurrentRepository().Add(PathSpecs{"go.md"})
 		require.NoError(t, err)
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestCommandReset(t *testing.T) {
 
 		CurrentLogger().SetVerboseLevel(VerboseDebug)
 
-		err := CurrentRepository().Add(PathSpecs{"go.md"})
+		_, err := CurrentRepository().Add(PathSpecs{"go.md"})
 		require.NoError(t, err)
 
 		// Check index file
@@ -246,7 +246,7 @@ func TestCommandCommit(t *testing.T) {
 	t.Run("Basic", func(t *testing.T) {
 		root := SetUpRepositoryFromGoldenDirNamed(t, "TestMinimal")
 
-		err := CurrentRepository().Add(PathSpecs{"go.md"})
+		_, err := CurrentRepository().Add(PathSpecs{"go.md"})
 		require.NoError(t, err)
 
 		err = CurrentRepository().Commit()
@@ -268,7 +268,7 @@ Guido van Rossum
 		require.ErrorContains(t, err, "nothing to commit")
 
 		// Create a second commit
-		err = CurrentRepository().Add(PathSpecs{"python.md"})
+		_, err = CurrentRepository().Add(PathSpecs{"python.md"})
 		require.NoError(t, err)
 
 		err = CurrentRepository().Commit()
@@ -289,7 +289,7 @@ func TestCommandPushPull(t *testing.T) {
 		}
 
 		// Push
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)
@@ -337,7 +337,7 @@ func TestCommandPushPull(t *testing.T) {
 		}
 
 		// Commit
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)
@@ -353,7 +353,7 @@ Who invented Python?
 
 Guido van Rossum
 `)
-		err = CurrentRepository().Add(AnyPath)
+		_, err = CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 
 		// Push
@@ -374,7 +374,7 @@ func TestCommandStatus(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestMinimal")
 
 		// Add
-		err := CurrentRepository().Add([]PathSpec{"go.md"})
+		_, err := CurrentRepository().Add([]PathSpec{"go.md"})
 		require.NoError(t, err)
 
 		// Edit a new file
@@ -439,7 +439,7 @@ Guido van Rossum
 		}, result.ChangesNotStaged)
 
 		// Add a new file
-		err = CurrentRepository().Add([]PathSpec{"python.md"})
+		_, err = CurrentRepository().Add([]PathSpec{"python.md"})
 		require.NoError(t, err)
 
 		// Status must report only the new files
@@ -465,7 +465,7 @@ Guido van Rossum
 		}, result.ChangesNotStaged)
 
 		// Add the old file
-		err = CurrentRepository().Add([]PathSpec{"go.md"})
+		_, err = CurrentRepository().Add([]PathSpec{"go.md"})
 		require.NoError(t, err)
 
 		// Status must report both files
@@ -520,7 +520,7 @@ func TestCommandDiff(t *testing.T) {
 
 		// Step 2: Add a file
 
-		err = CurrentRepository().Add([]PathSpec{"go.md"})
+		_, err = CurrentRepository().Add([]PathSpec{"go.md"})
 		require.NoError(t, err)
 
 		diffs, err = CurrentRepository().Diff(AnyPath, true) // Only the file staged must be returned
@@ -602,7 +602,7 @@ func TestCommandGC(t *testing.T) {
 
 		// Add a new file without committing
 		MustWriteFile(t, "go.md", `# Go`)
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 
 		// A pack file must have been created
@@ -619,7 +619,7 @@ func TestCommandGC(t *testing.T) {
 		// But the raw pack file still exists to speed up the next add
 		assert.FileExists(t, indexEntry.Ref().ObjectPath())
 
-		err = CurrentDB().GC(false)
+		_, err = CurrentDB().GC(false)
 		require.NoError(t, err)
 
 		// GC must have reclaimed the pack file
@@ -630,7 +630,7 @@ func TestCommandGC(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestMinimal")
 
 		// Add
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)
@@ -644,7 +644,7 @@ func TestCommandGC(t *testing.T) {
 
 		// Rewrite the file without referencing the media
 		MustWriteFile(t, "go.md", `# Go`)
-		err = CurrentRepository().Add(AnyPath)
+		_, err = CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)
@@ -654,12 +654,146 @@ func TestCommandGC(t *testing.T) {
 		// But the file has not been reclaimed
 		assert.FileExists(t, entryMedia.Ref().ObjectPath())
 
-		err = CurrentDB().GC(false)
+		_, err = CurrentDB().GC(false)
 		require.NoError(t, err)
 
 		// GC must have reclaimed the media files but not the markdown file
 		assert.FileExists(t, entryMarkdown.Ref().ObjectPath())
 		assert.NoFileExists(t, entryMedia.Ref().ObjectPath())
+	})
+
+	t.Run("Modified/Unmodified", func(t *testing.T) {
+		SetUpRepositoryFromTempDir(t)
+
+		// Step 1: Add new minimal files
+		MustWriteFile(t, "index.md", `
+---
+tags: programming
+---
+`)
+		MustWriteFile(t, "go.md", `
+# Go
+
+## Flashcard: Golang Creators
+
+(Golang) Who are the creators of Golang?
+
+---
+
+Robert Greisemer, Rob Pike, and Ken Thompson.
+`)
+		resultAdd, err := CurrentRepository().Add(AnyPath)
+		require.NoError(t, err)
+		require.Len(t, resultAdd.Upserted, 2) // 2 pack files
+		require.Len(t, resultAdd.Deleted, 0)
+
+		resultGC, err := CurrentDB().GC(false) // Nothing has changed, nothing to reclaim
+		require.NoError(t, err)
+		assert.Len(t, resultGC.ReclaimedPackFiles, 0)
+		assert.Len(t, resultGC.ReclaimedBlobs, 0)
+
+		// Step 2: Modify the file to force a new pack file + new blob
+		time.Sleep(1 * time.Millisecond) // Ensure mtimes are different
+		MustWriteFile(t, "go.md", `
+# Go
+
+## Flashcard: Golang Creators
+
+(Golang) Who created Golang?
+
+---
+
+Robert Greisemer, Rob Pike, and Ken Thompson.
+`)
+		resultAdd, err = CurrentRepository().Add(AnyPath)
+		require.NoError(t, err)
+		require.Len(t, resultAdd.Upserted, 1) // Content changed = new pack file
+
+		resultGC, err = CurrentDB().GC(false) // The old files must not be reclaimed as still not committed
+		require.NoError(t, err)
+		assert.Len(t, resultGC.ReclaimedPackFiles, 0)
+		assert.Len(t, resultGC.ReclaimedBlobs, 0)
+
+		// Commit the changes
+		err = CurrentRepository().Commit()
+		require.NoError(t, err)
+
+		// The old files can now be reclaimed
+		resultGC, err = CurrentDB().GC(false)
+		require.NoError(t, err)
+		assert.Len(t, resultGC.ReclaimedPackFiles, 1)
+		assert.Len(t, resultGC.ReclaimedBlobs, 1)
+
+		// Step 3: Edit the index file
+		// All pack files/blobs to be recreated
+		time.Sleep(1 * time.Millisecond) // Ensure mtimes are different
+		MustWriteFile(t, "index.md", `
+---
+tags: go
+---
+`)
+
+		resultAdd, err = CurrentRepository().Add(AnyPath)
+		require.NoError(t, err)
+		require.Len(t, resultAdd.Upserted, 2) // Both content changed = new pack files
+		require.Len(t, resultAdd.Deleted, 0)
+
+		err = CurrentRepository().Commit()
+		require.NoError(t, err)
+
+		resultGC, err = CurrentDB().GC(false) // All old files must not be reclaimed as still not committed
+		require.NoError(t, err)
+		assert.Len(t, resultGC.ReclaimedPackFiles, 1) // The go.md pack file has been overwritten as the hash stayed the same
+		assert.Len(t, resultGC.ReclaimedBlobs, 1)     // Idem for the associated blob
+
+		// Step 4: Try to add the same unchanged file again with GC between each.
+		// Nothing should change, nothing to reclaim.
+		for range []int{1, 2, 3} {
+			resultAdd, err = CurrentRepository().Add(AnyPath)
+			require.NoError(t, err)
+			require.Len(t, resultAdd.Upserted, 0) // Nothing has changed, nothing to add
+			require.Len(t, resultAdd.Deleted, 0)  // Nothing has changed, nothing to delete
+
+			resultGC, err := CurrentDB().GC(false) // Nothing has changed, nothing to reclaim
+			require.NoError(t, err)
+			assert.Len(t, resultGC.ReclaimedPackFiles, 0)
+			assert.Len(t, resultGC.ReclaimedBlobs, 0)
+		}
+
+		// Step 5: Delete go.md
+		MustDeleteFile(t, "go.md")
+		resultAdd, err = CurrentRepository().Add(AnyPath)
+		require.NoError(t, err)
+		require.Len(t, resultAdd.Upserted, 0)
+		require.Len(t, resultAdd.Deleted, 1) // The go.md pack file has a tombstone (the associated blob will be garbage-collected later)
+
+		resultGC, err = CurrentDB().GC(false) // Still not committed, nothing to reclaim
+		require.NoError(t, err)
+		assert.Len(t, resultGC.ReclaimedPackFiles, 0)
+		assert.Len(t, resultGC.ReclaimedBlobs, 0)
+
+		// Commit the changes
+		err = CurrentRepository().Commit()
+		require.NoError(t, err)
+
+		resultGC, err = CurrentDB().GC(false)
+		require.NoError(t, err)
+		assert.Len(t, resultGC.ReclaimedPackFiles, 1) // The go.md pack file has been deleted
+		assert.Len(t, resultGC.ReclaimedBlobs, 1)     // Idem for the associated blob
+
+		// Step 6: Try to add the same unchanged file again with GC between each.
+		// Nothing should change, nothing to reclaim.
+		for range []int{1, 2, 3} {
+			resultAdd, err = CurrentRepository().Add(AnyPath)
+			require.NoError(t, err)
+			require.Len(t, resultAdd.Upserted, 0) // Nothing has changed, nothing to add
+			require.Len(t, resultAdd.Deleted, 0)  // Nothing has changed, nothing to delete
+
+			resultGC, err := CurrentDB().GC(false) // Nothing has changed, nothing to reclaim
+			require.NoError(t, err)
+			assert.Len(t, resultGC.ReclaimedPackFiles, 0)
+			assert.Len(t, resultGC.ReclaimedBlobs, 0)
+		}
 	})
 
 }

--- a/internal/core/commands_test.go
+++ b/internal/core/commands_test.go
@@ -619,7 +619,7 @@ func TestCommandGC(t *testing.T) {
 		// But the raw pack file still exists to speed up the next add
 		assert.FileExists(t, indexEntry.Ref().ObjectPath())
 
-		err = CurrentDB().GC()
+		err = CurrentDB().GC(false)
 		require.NoError(t, err)
 
 		// GC must have reclaimed the pack file
@@ -654,7 +654,7 @@ func TestCommandGC(t *testing.T) {
 		// But the file has not been reclaimed
 		assert.FileExists(t, entryMedia.Ref().ObjectPath())
 
-		err = CurrentDB().GC()
+		err = CurrentDB().GC(false)
 		require.NoError(t, err)
 
 		// GC must have reclaimed the media files but not the markdown file

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -23,9 +23,6 @@ import (
 	"github.com/julien-sobczak/the-notewriter/pkg/text"
 )
 
-//go:embed config.jsonnet
-var DefaultConfigFile string // FIXME remove
-
 //go:embed config.jsonnet.tmpl
 var DefaultConfigTemplateFile string
 
@@ -792,14 +789,23 @@ var DefaultConfigOptions = ConfigOptions{
 	MediaConverter: "ffmpeg",
 }
 
+// InitConfigFileFromDirectory initializes the default configuration files under a .nt subdirectory.
 func InitConfigFileFromDirectory(path string, options ConfigOptions) error {
-	CurrentLogger().Debugf("✨ Set up file %s/.nt/config.jsonnet", path)
+	CurrentLogger().Debugf("✨ Set up configuration files under %s/.nt", path)
+
+	// Init .nt/ directory
+	ntPath := filepath.Join(path, ".nt")
+	if err := os.MkdirAll(ntPath, 0755); err != nil {
+		return fmt.Errorf("failed to create .nt directory: %v", err)
+	}
+	CurrentLogger().Infof("✅ Created directory %s", ntPath)
 
 	// Init .nt/nt.libsonnet file
-	ntConfigLibPath := filepath.Join(path, ".nt", "nt.libsonnet")
+	ntConfigLibPath := filepath.Join(ntPath, "nt.libsonnet")
 	if err := os.WriteFile(ntConfigLibPath, []byte(DefaultConfigLibFile), 0644); err != nil {
 		return err
 	}
+	CurrentLogger().Infof("✅ Created file %s/nt.libsonnet", ntPath)
 
 	// Generate config.jsonnet file content.
 	// We use a template to allow for dynamic values (convenient in tests).
@@ -815,10 +821,11 @@ func InitConfigFileFromDirectory(path string, options ConfigOptions) error {
 	}
 
 	// Init .nt/config.jsonnet file
-	ntConfigPath := filepath.Join(path, ".nt", "config.jsonnet")
+	ntConfigPath := filepath.Join(ntPath, "config.jsonnet")
 	if err := os.WriteFile(ntConfigPath, buf.Bytes(), 0644); err != nil {
 		return err
 	}
+	CurrentLogger().Infof("✅ Created file %s/config.jsonnet", ntPath)
 
 	return nil
 }

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -412,18 +412,14 @@ func TestJsonnet(t *testing.T) {
 }
 
 func TestStaticConfigFiles(t *testing.T) {
-	vm := jsonnet.MakeVM()
-
 	// Copy static files to temporary directory
 	dir := t.TempDir()
-	libFilename := filepath.Join(dir, "nt.libsonnet")
-	configFilename := filepath.Join(dir, "config.jsonnet")
-	err := os.WriteFile(libFilename, []byte(DefaultConfigLibFile), 0644)
-	require.NoError(t, err)
-	err = os.WriteFile(configFilename, []byte(DefaultConfigFile), 0644)
+	err := InitConfigFileFromDirectory(dir, DefaultConfigOptions)
 	require.NoError(t, err)
 
-	actual, err := vm.EvaluateFile(configFilename)
+	// Evaluate generated configuration file
+	vm := jsonnet.MakeVM()
+	actual, err := vm.EvaluateFile(filepath.Join(dir, ".nt", "config.jsonnet"))
 	require.NoError(t, err)
 	t.Log(actual)
 }

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -237,7 +237,7 @@ func (db *DB) UpsertPackFiles(packFiles ...*PackFile) error {
 				}
 			}
 		}
-		CurrentLogger().Infof("💾 Upserted pack file %s", filepath.Base(packFile.ObjectPath()))
+		CurrentLogger().Infof("💾 Upserted pack file %s (%s)", filepath.Base(packFile.ObjectPath()), packFile.FileRelativePath)
 	}
 	return nil
 }
@@ -251,7 +251,7 @@ func (db *DB) DeletePackFiles(packFiles ...*PackFile) error {
 				if err := statefulObj.Delete(); err != nil {
 					return err
 				}
-				CurrentLogger().Infof("💾 Deleted pack file %s", filepath.Base(packFile.ObjectPath()))
+				CurrentLogger().Infof("💾 Deleted pack file %s (%s)", filepath.Base(packFile.ObjectPath()), packFile.FileRelativePath)
 			}
 			// Ignore operations
 		}
@@ -367,8 +367,25 @@ func (db *DB) Diff() (string, error) {
 	return diff.String(), nil
 }
 
+type GCResult struct {
+	ReclaimedPackFiles []oid.OID // List of pack files deleted
+	ReclaimedBlobs     []oid.OID // List of blobs deleted
+}
+
+func (r *GCResult) AddBlob(oid oid.OID) {
+	if !slices.Contains(r.ReclaimedBlobs, oid) {
+		r.ReclaimedBlobs = append(r.ReclaimedBlobs, oid)
+	}
+}
+
+func (r *GCResult) AddPackFile(oid oid.OID) {
+	if !slices.Contains(r.ReclaimedPackFiles, oid) {
+		r.ReclaimedPackFiles = append(r.ReclaimedPackFiles, oid)
+	}
+}
+
 // GC removes non referenced objects/blobs in the local directory.
-func (db *DB) GC(dryRun bool) error {
+func (db *DB) GC(dryRun bool) (*GCResult, error) {
 	// Why GC is required? Why commits cannot do the housekeeping directly?
 	//
 	// The main reason is to reclaim disk space (and thus limit the storage consumption, especially useful for remotes).
@@ -386,6 +403,7 @@ func (db *DB) GC(dryRun bool) error {
 	objectDir := index.ObjectsDir()
 
 	var reclaimedFiles []string
+	var result GCResult
 
 	// Traverse the file system to find orphan blobs and orphan pack files
 	err := filepath.WalkDir(objectDir, func(path string, info fs.DirEntry, err error) error {
@@ -408,9 +426,11 @@ func (db *DB) GC(dryRun bool) error {
 				// Delete blobs first
 				for _, blobRef := range packFile.BlobRefs {
 					reclaimedFiles = append(reclaimedFiles, blobRef.ObjectPath())
+					result.AddBlob(blobRef.OID)
 				}
 				// Delete pack file last
 				reclaimedFiles = append(reclaimedFiles, packFile.ObjectPath())
+				result.AddPackFile(oid)
 			}
 		}
 
@@ -420,13 +440,14 @@ func (db *DB) GC(dryRun bool) error {
 			if blob == nil {
 				// This blob is not longer present in the index.
 				reclaimedFiles = append(reclaimedFiles, BlobPath(oid))
+				result.AddBlob(oid)
 			}
 		}
 
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Batch the deletions having having remove duplicates
@@ -438,11 +459,11 @@ func (db *DB) GC(dryRun bool) error {
 			continue
 		}
 		if err := SafeRemove(path); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return &result, nil
 }
 
 /* Utility */

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -368,7 +368,7 @@ func (db *DB) Diff() (string, error) {
 }
 
 // GC removes non referenced objects/blobs in the local directory.
-func (db *DB) GC() error {
+func (db *DB) GC(dryRun bool) error {
 	// Why GC is required? Why commits cannot do the housekeeping directly?
 	//
 	// The main reason is to reclaim disk space (and thus limit the storage consumption, especially useful for remotes).
@@ -381,8 +381,6 @@ func (db *DB) GC() error {
 	// * Pack files are created when running 'nt add' but are not deleted on disk when running 'nt reset' (only removed in index)
 	//   to avoid recreating blobs (especially using for medias which require conversion).
 	//   If a file never added again, the packfile can be safely removed.
-
-	CurrentLogger().Info("Reclaiming blobs...")
 
 	index := CurrentIndex()
 	objectDir := index.ObjectsDir()
@@ -435,6 +433,10 @@ func (db *DB) GC() error {
 	slices.Sort(reclaimedFiles)
 	reclaimedFiles = slices.Compact(reclaimedFiles)
 	for _, path := range reclaimedFiles {
+		if dryRun {
+			CurrentLogger().Infof("🗑️ Would delete: %s", path) // TODO log on stdout/stderr directly?
+			continue
+		}
 		if err := SafeRemove(path); err != nil {
 			return err
 		}

--- a/internal/core/database_test.go
+++ b/internal/core/database_test.go
@@ -67,7 +67,7 @@ class SillyClass:
 `))
 
 	// Add to persist objects in DB
-	err := CurrentRepository().Add(AnyPath)
+	_, err := CurrentRepository().Add(AnyPath)
 	require.NoError(t, err)
 
 	require.Equal(t, 2, MustCountFiles(t))
@@ -206,7 +206,7 @@ func TestStatsOnDisk(t *testing.T) {
 	require.Equal(t, int64(0), stats.TotalSizeKB)
 
 	// Add
-	err = CurrentRepository().Add(AnyPath)
+	_, err = CurrentRepository().Add(AnyPath)
 	require.NoError(t, err)
 	statsAdd, err := CurrentDB().StatsOnDisk()
 	require.NoError(t, err)

--- a/internal/core/flashcard_test.go
+++ b/internal/core/flashcard_test.go
@@ -170,7 +170,7 @@ Who invented Python?
 Guido van Rossum
 `)
 
-		err := CurrentRepository().Add(PathSpecs{"python.md"})
+		_, err := CurrentRepository().Add(PathSpecs{"python.md"})
 		require.NoError(t, err)
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)

--- a/internal/core/hook.go
+++ b/internal/core/hook.go
@@ -36,7 +36,7 @@ func (n *Note) RunHooks(hookNames []string, manual bool) error {
 
 	// Do not trigger hook with tag `#manual` except when using `nt run-hook` command
 	if n.Tags.Includes("manual") && !manual {
-		CurrentLogger().Infof("🙈 Skipping hooks as tag 'manual' is present")
+		CurrentLogger().Warnf("🙈 Skipping hooks as tag 'manual' is present")
 		return nil
 	}
 

--- a/internal/core/hook_test.go
+++ b/internal/core/hook_test.go
@@ -11,7 +11,7 @@ func TestHooks(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestHooks")
 
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 
 		notes, err := CurrentRepository().SearchNotes(`slug:hooks-todo-dup`)
@@ -25,7 +25,7 @@ func TestHooks(t *testing.T) {
 	t.Run("Missing", func(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestHooks")
 
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 
 		notes, err := CurrentRepository().SearchNotes(`slug:hooks-note-missing`)
@@ -39,7 +39,7 @@ func TestHooks(t *testing.T) {
 	t.Run("Not executable", func(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestHooks")
 
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 
 		notes, err := CurrentRepository().SearchNotes(`slug:hooks-note-program`)
@@ -53,7 +53,7 @@ func TestHooks(t *testing.T) {
 	t.Run("Multiple executables", func(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestHooks")
 
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 
 		notes, err := CurrentRepository().SearchNotes(`slug:hooks-note-multiple`)
@@ -67,7 +67,7 @@ func TestHooks(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestHooks")
 
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 
 		notes, err := CurrentRepository().SearchNotes(`slug:hooks-note-error`)

--- a/internal/core/index.go
+++ b/internal/core/index.go
@@ -48,17 +48,20 @@ type IndexEntry struct {
 	PackFileOID oid.OID `yaml:"packfile_oid"`
 	// File last modification date
 	MTime time.Time `yaml:"mtime"`
+	// File last indexation date
+	ITime time.Time `yaml:"itime"`
 	// Size of the file (can be useful to detect changes)
 	Size int64 `yaml:"size" json:"size"`
 
 	// True when a file has been staged
-	Staged bool `yaml:"staged"`
+	Staged bool `yaml:"staged,omitempty"`
 	// Save but when the file has been staged (= different object under .nt/objects)
-	StagedPackFileOID oid.OID `yaml:"staged_packfile_oid"`
+	StagedPackFileOID oid.OID `yaml:"staged_packfile_oid,omitempty"`
 	// Timestamp when the file has been detected as deleted
-	StagedTombstone time.Time `yaml:"staged_tombstone"`
-	StagedMTime     time.Time `yaml:"staged_mtime"`
-	StagedSize      int64     `yaml:"staged_size"`
+	StagedTombstone time.Time `yaml:"staged_tombstone,omitempty"`
+	StagedMTime     time.Time `yaml:"staged_mtime,omitempty"`
+	StagedITime     time.Time `yaml:"staged_itime,omitempty"`
+	StagedSize      int64     `yaml:"staged_size,omitempty"`
 }
 
 // NewIndexEntry creates a new index entry from a pack file.
@@ -97,10 +100,42 @@ func (i *IndexEntry) Ref() PackFileRef {
 	}
 }
 
+func (i *IndexEntry) LastMTime() time.Time {
+	// Staged entry takes precedence over the committed entry.
+	if i.Staged {
+		return i.StagedMTime
+	}
+	return i.MTime
+}
+
+func (i *IndexEntry) LastITime() time.Time {
+	// Staged entry takes precedence over the committed entry.
+	if i.Staged {
+		return i.StagedITime
+	}
+	return i.ITime
+}
+
+func (i *IndexEntry) ModifiedBefore(t time.Time) bool {
+	return i.LastMTime().Before(t)
+}
+
+func (i *IndexEntry) ModifiedAfter(t time.Time) bool {
+	return i.LastMTime().After(t)
+}
+
+func (i *IndexEntry) ModifiedBeforeLastIndexation(o *IndexEntry) bool {
+	if o == nil {
+		return false // no previous entry to compare with = modified after last "unknown" indexation
+	}
+	return i.LastMTime().Before(o.LastITime())
+}
+
 func (i *IndexEntry) Stage(newPackFile *PackFile) {
 	i.Staged = true
 	i.StagedPackFileOID = newPackFile.OID
 	i.StagedMTime = newPackFile.FileMTime
+	i.StagedITime = clock.Now()
 	i.StagedSize = newPackFile.FileSize
 	i.StagedTombstone = time.Time{} // Zero value
 }
@@ -120,6 +155,7 @@ func (i *IndexEntry) Reset() {
 	i.Staged = false
 	i.StagedPackFileOID = ""
 	i.StagedMTime = time.Time{}
+	i.StagedITime = time.Time{}
 	i.StagedSize = 0
 	i.StagedTombstone = time.Time{}
 	// Let the pack file to be garbage collected.
@@ -133,10 +169,12 @@ func (i *IndexEntry) Commit() {
 	i.Staged = false
 	i.PackFileOID = i.StagedPackFileOID
 	i.MTime = i.StagedMTime
+	i.ITime = i.StagedITime
 	i.Size = i.StagedSize
 	// Clear staged values
 	i.StagedPackFileOID = oid.Nil
 	i.StagedMTime = time.Time{}
+	i.StagedITime = time.Time{}
 	i.StagedSize = 0
 	i.StagedTombstone = time.Time{}
 }
@@ -269,7 +307,7 @@ func (i *Index) Save() error {
 // GetEntryByPackFileOID returns the entry associated with a pack file OID.
 func (i *Index) GetEntryByPackFileOID(oid oid.OID) (*IndexEntry, bool) {
 	for _, entry := range i.Entries {
-		if entry.PackFileOID == oid {
+		if entry.PackFileOID == oid || entry.StagedPackFileOID == oid {
 			return entry, true
 		}
 	}
@@ -370,6 +408,7 @@ func (i *Index) Stage(packFiles ...*PackFile) error {
 		entry := i.GetEntry(packFile.FileRelativePath)
 		if entry == nil {
 			entry = NewIndexEntry(packFile)
+			entry.ITime = clock.Now()
 			i.Entries = append(i.Entries, entry)
 		}
 		entry.Stage(packFile)
@@ -743,13 +782,13 @@ func (i *Index) Exists(relativePath string) bool {
 	return entry != nil
 }
 
-// Modified returns true if the file has been modified since last indexation.
-func (i *Index) Modified(relativePath string, mtime time.Time) bool {
+// ModifiedBefore returns true if the file has been modified since the given time.
+func (i *Index) ModifiedBefore(relativePath string, t time.Time) bool {
 	entry := i.GetEntry(relativePath)
 	if entry == nil {
-		return true
+		return true // File does not exist in index = new file!
 	}
-	return mtime.After(entry.MTime)
+	return entry.ModifiedBefore(t)
 }
 
 // ShortOID returns a short version of the OID based on the known OIDs.

--- a/internal/core/index_test.go
+++ b/internal/core/index_test.go
@@ -21,6 +21,7 @@ func TestIndexEntry(t *testing.T) {
 			RelativePath: "go.md",
 			PackFileOID:  oid.MustParse("1234567890123456789012345678901234567890"),
 			MTime:        clock.Now(),
+			ITime:        clock.Now(),
 			Size:         1,
 			Staged:       false,
 		}
@@ -30,10 +31,12 @@ func TestIndexEntry(t *testing.T) {
 			RelativePath:      "go.md",
 			PackFileOID:       oid.MustParse("1234567890123456789012345678901234567890"),
 			MTime:             clock.Now(),
+			ITime:             clock.Now(),
 			Size:              1,
 			Staged:            true,
 			StagedPackFileOID: oid.MustParse("33f1c9b2e0f94af4ac8c374051d7cf31724140ac"),
 			StagedMTime:       clock.Now(),
+			StagedITime:       clock.Now(),
 			StagedSize:        2,
 		}
 		assert.Equal(t, `entry "go.md" (packfile: 1234567890123456789012345678901234567890 => 33f1c9b2e0f94af4ac8c374051d7cf31724140ac)`, entryStaged.String())
@@ -42,6 +45,7 @@ func TestIndexEntry(t *testing.T) {
 			RelativePath:    "go.md",
 			PackFileOID:     oid.MustParse("1234567890123456789012345678901234567890"),
 			MTime:           clock.Now(),
+			ITime:           clock.Now(),
 			Size:            1,
 			Staged:          true,
 			StagedTombstone: clock.Now(),
@@ -89,12 +93,14 @@ func TestIndex(t *testing.T) {
 			RelativePath: "go.md",
 			PackFileOID:  packFile.OID,
 			MTime:        clock.Now(),
+			ITime:        clock.Now(),
 			Size:         1,
 			// File has just been staged
 			Staged:            true,
 			StagedPackFileOID: packFile.OID,
 			StagedTombstone:   time.Time{},
 			StagedMTime:       clock.Now(),
+			StagedITime:       clock.Now(),
 			StagedSize:        1,
 		}, entry)
 
@@ -115,12 +121,14 @@ func TestIndex(t *testing.T) {
 			RelativePath: "go.md",
 			PackFileOID:  packFile.OID,
 			MTime:        clock.Now(),
+			ITime:        clock.Now(),
 			Size:         1,
 			// File has just been staged
 			Staged:            false,
 			StagedPackFileOID: oid.Nil,
 			StagedTombstone:   time.Time{},
 			StagedMTime:       time.Time{},
+			StagedITime:       time.Time{},
 			StagedSize:        0,
 		}, entry)
 	})
@@ -192,12 +200,14 @@ func TestIndex(t *testing.T) {
 			RelativePath: "go.md",
 			PackFileOID:  packFile1.OID,
 			MTime:        clock.Now(),
+			ITime:        clock.Now(),
 			Size:         1,
 			// File has just been staged
 			Staged:            false,
 			StagedPackFileOID: oid.Nil,
 			StagedTombstone:   time.Time{},
 			StagedMTime:       time.Time{},
+			StagedITime:       time.Time{},
 			StagedSize:        0,
 		}, entry1)
 		// Second entry must be staged
@@ -205,12 +215,14 @@ func TestIndex(t *testing.T) {
 			RelativePath: "python.md",
 			PackFileOID:  packFile2.OID,
 			MTime:        clock.Now(),
+			ITime:        clock.Now(),
 			Size:         1,
 			// File has just been staged
 			Staged:            true,
 			StagedPackFileOID: packFile2.OID,
 			StagedTombstone:   time.Time{},
 			StagedMTime:       clock.Now(),
+			StagedITime:       clock.Now(),
 			StagedSize:        1,
 		}, entry2)
 
@@ -247,12 +259,14 @@ func TestIndex(t *testing.T) {
 			RelativePath: "python.md",
 			PackFileOID:  packFile2.OID,
 			MTime:        clock.Now(),
+			ITime:        clock.Now(),
 			Size:         1,
 			// File has been staged again
 			Staged:            true,
 			StagedPackFileOID: newPackFile2.OID,
 			StagedTombstone:   time.Time{},
 			StagedMTime:       clock.Now(),
+			StagedITime:       clock.Now(),
 			StagedSize:        1,
 		}, entry2)
 
@@ -322,7 +336,7 @@ func TestIndex(t *testing.T) {
 		// Delete the first file
 		idx.SetTombstone(packFile1.FileRelativePath)
 		countObjectsAfter := len(idx.Objects)
-		require.NotNil(t, idx.GetEntry("go.md"))                             // Still there...
+		require.NotNil(t, idx.GetEntry("go.md"))                            // Still there...
 		assert.Equal(t, clock.Now(), idx.GetEntry("go.md").StagedTombstone) // ...with a tombstone
 		assert.Equal(t, countObjectsBefore, countObjectsAfter)              // no change in the number of objects as the pack file is still there with a tombstone
 
@@ -404,13 +418,13 @@ func TestIndex(t *testing.T) {
 		require.NoError(t, idx.Commit())
 
 		// File not in index
-		assert.True(t, idx.Modified("python.md", clock.Now()))
+		assert.True(t, idx.ModifiedBefore("python.md", clock.Now()))
 
 		// File in index, not modified
-		assert.False(t, idx.Modified("go.md", clock.Now()))
+		assert.False(t, idx.ModifiedBefore("go.md", clock.Now()))
 
 		// File in index, modified
-		assert.True(t, idx.Modified("go.md", clock.Now().Add(1*time.Hour)))
+		assert.True(t, idx.ModifiedBefore("go.md", clock.Now().Add(1*time.Hour)))
 	})
 
 	t.Run("ShortOID", func(t *testing.T) {

--- a/internal/core/lint.go
+++ b/internal/core/lint.go
@@ -70,6 +70,9 @@ func (v Violation) String() string {
 type LintRule func(*ParsedFile, *Query, []any) ([]*Violation, error)
 
 var LintRulesFn = map[string]LintRule{
+	// Enforce no empty titles
+	"no-empty-title": NoEmptyTitle,
+
 	// Enforce no duplicate between note titles
 	"no-duplicate-note-title": NoDuplicateNoteTitle,
 
@@ -102,6 +105,32 @@ var LintRulesFn = map[string]LintRule{
 }
 
 /* Rules */
+
+// NoEmptyTitle implements the rule "no-empty-title".
+func NoEmptyTitle(file *ParsedFile, query *Query, args []any) ([]*Violation, error) {
+	var violations []*Violation
+
+	if text.IsBlank(file.ShortTitle.String()) {
+		violations = append(violations, &Violation{
+			Name:         "no-empty-title",
+			Message:      "note with empty title",
+			RelativePath: file.RelativePath,
+			Line:         1, // The title is always on the first line
+		})
+	}
+	for _, note := range file.Notes {
+		if text.IsBlank(note.ShortTitle.String()) {
+			violations = append(violations, &Violation{
+				Name:         "no-empty-title",
+				Message:      "note with empty title",
+				RelativePath: file.RelativePath,
+				Line:         note.Line,
+			})
+		}
+	}
+
+	return violations, nil
+}
 
 // NoDuplicateNoteTitle implements the rule "no-duplicate-note-title".
 func NoDuplicateNoteTitle(file *ParsedFile, query *Query, args []any) ([]*Violation, error) {

--- a/internal/core/lint_test.go
+++ b/internal/core/lint_test.go
@@ -7,6 +7,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNoEmptyTitle(t *testing.T) {
+	SetUpRepositoryFromGoldenDirNamed(t, "TestLint")
+
+	file := ParseFileFromRelativePath(t, "no-empty-title.md")
+
+	violations, err := NoEmptyTitle(file, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, []*Violation{
+		{
+			Name:         "no-empty-title",
+			RelativePath: "no-empty-title.md",
+			Message:      `note with empty title`,
+			Line:         1,
+		},
+		{
+			Name:         "no-empty-title",
+			RelativePath: "no-empty-title.md",
+			Message:      `note with empty title`,
+			Line:         3,
+		},
+	}, violations)
+}
+
 func TestNoDuplicateNoteTitle(t *testing.T) {
 	SetUpRepositoryFromGoldenDirNamed(t, "TestLint")
 

--- a/internal/core/note_test.go
+++ b/internal/core/note_test.go
@@ -105,6 +105,46 @@ func TestNote(t *testing.T) {
 	AssertNoNotes(t)
 }
 
+func TestNoteHooks(t *testing.T) {
+
+	t.Run("HasHooks", func(t *testing.T) {
+		SetUpRepositoryFromTempDir(t)
+
+		// Insert the note
+		MustWriteFile(t, "go.md", text.UnescapeTestContent(`# Go
+
+## Note: Golang History
+
+‛@hook: gist‛
+
+Golang was designed by Robert Greisemer, Rob Pike, and Ken Thompson at Google in 2007.
+		`))
+
+		_, err := CurrentRepository().Add(PathSpecs{"go.md"})
+		require.NoError(t, err)
+		err = CurrentRepository().Commit()
+		require.NoError(t, err)
+
+		// Check in database
+		note := MustFindNoteByTitle(t, "Note: Golang History")
+		assert.True(t, note.HasHooks())
+		assert.Equal(t, []string{"gist"}, note.GetHooks())
+
+		// Check in objects
+		packFile, err := CurrentIndex().ReadLastPackFile("go.md")
+		require.NoError(t, err)
+		require.NotNil(t, packFile)
+
+		packObjects := packFile.PackObjects
+		require.Len(t, packObjects, 2) // File + Note
+		note, ok := packObjects[1].Read().(*Note)
+		require.True(t, ok)
+		assert.True(t, note.HasHooks())
+		assert.Equal(t, []string{"gist"}, note.GetHooks())
+	})
+
+}
+
 func TestNoteFormats(t *testing.T) {
 	FreezeOn(t, "2023-01-01 01:12:30")
 
@@ -290,7 +330,7 @@ Who invented Python?
 Guido van Rossum
 `)
 
-		err := CurrentRepository().Add(PathSpecs{"python.md"})
+		_, err := CurrentRepository().Add(PathSpecs{"python.md"})
 		require.NoError(t, err)
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)
@@ -335,7 +375,7 @@ Who invented Python?
 Guido van Rossum
 `)
 
-		err := CurrentRepository().Add(PathSpecs{"python.md"})
+		_, err := CurrentRepository().Add(PathSpecs{"python.md"})
 		require.NoError(t, err)
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)

--- a/internal/core/nt.libsonnet
+++ b/internal/core/nt.libsonnet
@@ -34,6 +34,10 @@
 
     // Declare available Linter rules
     LintRules: {
+        NoEmptyTitle()::
+            {
+                name: "no-empty-title",
+            },
         NoDuplicateNoteTitle()::
             {
                 name: "no-duplicate-note-title",

--- a/internal/core/operations_test.go
+++ b/internal/core/operations_test.go
@@ -151,7 +151,7 @@ Who invented Python?
 Guido van Rossum
 `)
 
-	err := CurrentRepository().Add(PathSpecs{"python.md"})
+	_, err := CurrentRepository().Add(PathSpecs{"python.md"})
 	require.NoError(t, err)
 	err = CurrentRepository().Commit()
 	require.NoError(t, err)

--- a/internal/core/packfile.go
+++ b/internal/core/packfile.go
@@ -167,6 +167,7 @@ func (p *PackObject) Read() Packable {
 	case "file":
 		file := new(File)
 		p.Data.Unmarshal(file)
+		file.Attributes = file.Attributes.CastOrIgnore(CurrentConfigFile().Attributes)
 		return file
 	case "flashcard":
 		flashcard := new(Flashcard)
@@ -179,6 +180,7 @@ func (p *PackObject) Read() Packable {
 	case "note":
 		note := new(Note)
 		p.Data.Unmarshal(note)
+		note.Attributes = note.Attributes.CastOrIgnore(CurrentConfigFile().Attributes)
 		return note
 	case "link":
 		link := new(GoLink)
@@ -202,7 +204,7 @@ func (p *PackObject) Read() Packable {
 
 // LoadPackFileFromPath reads a pack file file on disk.
 func LoadPackFileFromPath(path string) (*PackFile, error) {
-	CurrentLogger().Infof("🤓 Loading pack file %s", path)
+	CurrentLogger().Debugf("🤓 Loading pack file %s", path)
 	in, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/internal/core/parser.go
+++ b/internal/core/parser.go
@@ -407,7 +407,7 @@ func (p *ParsedFile) extractNotes() ([]*ParsedNote, error) {
 			for _, parsedNote := range parsedNotes {
 				generatedNotes, err := preprocessor(p, parsedNote)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failing preprocessor %q on note %q (%s:%d): %v", preprocessorName, parsedNote.ShortTitle, parsedNote.RelativePath, parsedNote.Line, err)
 				}
 				if len(generatedNotes) > 0 {
 					newParsedNotes = append(newParsedNotes, generatedNotes...)

--- a/internal/core/parser_test.go
+++ b/internal/core/parser_test.go
@@ -803,7 +803,7 @@ Reread the book in 10 years to see how my perspective has changed.
 			"isbn":          "978-0525559474",
 			"review_rating": int64(20),
 			"review_stars":  int64(5),
-			"read_date":     time.Date(2025, 04, 01, 0, 0, 0, 0, time.UTC),
+			"read_date":     "2025-04-01",
 			"draft":         false,
 		}), note.Attributes)
 

--- a/internal/core/regression_test.go
+++ b/internal/core/regression_test.go
@@ -75,7 +75,7 @@ func TestRegression(t *testing.T) {
 		require.NoError(t, err)
 
 		if edition.RunGC {
-			err = CurrentDB().GC()
+			err = CurrentDB().GC(false)
 			require.NoError(t, err)
 		}
 

--- a/internal/core/regression_test.go
+++ b/internal/core/regression_test.go
@@ -13,7 +13,7 @@ import (
 func TestRegression(t *testing.T) {
 	root := SetUpRepositoryFromGoldenDirNamed(t, "TestComplex")
 
-	err := CurrentRepository().Add(AnyPath)
+	_, err := CurrentRepository().Add(AnyPath)
 	require.NoError(t, err)
 
 	err = CurrentRepository().Commit()
@@ -68,14 +68,14 @@ func TestRegression(t *testing.T) {
 			change.Apply(t, root)
 		}
 
-		err := CurrentRepository().Add(AnyPath)
+		_, err := CurrentRepository().Add(AnyPath)
 		require.NoError(t, err)
 
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)
 
 		if edition.RunGC {
-			err = CurrentDB().GC(false)
+			_, err = CurrentDB().GC(false)
 			require.NoError(t, err)
 		}
 

--- a/internal/core/repository.go
+++ b/internal/core/repository.go
@@ -259,8 +259,31 @@ func (r *Repository) MustLint(paths PathSpecs) {
 	}
 }
 
+type AddResult struct {
+	// Pack files that were upserted
+	Upserted []oid.OID
+	// Pack files that were deleted
+	Deleted []oid.OID
+}
+
+func (r *AddResult) Upsert(packFiles ...*PackFile) {
+	for _, packFile := range packFiles {
+		if !slices.Contains(r.Upserted, packFile.OID) {
+			r.Upserted = append(r.Upserted, packFile.OID)
+		}
+	}
+}
+
+func (r *AddResult) Delete(packFiles ...*PackFile) {
+	for _, packFile := range packFiles {
+		if !slices.Contains(r.Deleted, packFile.OID) {
+			r.Deleted = append(r.Deleted, packFile.OID)
+		}
+	}
+}
+
 // Add implements the command `nt add`
-func (r *Repository) Add(paths PathSpecs) error {
+func (r *Repository) Add(paths PathSpecs) (*AddResult, error) {
 	r.MustLint(paths)
 
 	CurrentConfig().DryRun = false
@@ -295,9 +318,11 @@ func (r *Repository) Add(paths PathSpecs) error {
 		// - The file was modified since the last known timestamp
 		// - The parent file was modified since the last known timestamp (ex: new attribute to propagate)
 
+		entry := CurrentIndex().GetEntry(relativePath)
 		var mdParentFile *markdown.File
 		parentEntry := CurrentIndex().GetParentEntry(relativePath)
 		if parentEntry != nil {
+			// Read on disk to have the latest version (NB: pack files are written on disk before being upserted in database)
 			packFile, err := CurrentIndex().ReadPackFile(parentEntry.PackFileOID)
 			if err != nil {
 				return err
@@ -316,14 +341,22 @@ func (r *Repository) Add(paths PathSpecs) error {
 			}
 		}
 
-		mdFileModified := CurrentIndex().Modified(relativePath, mdFile.MTime)
+		mdFileModified := true
+		if entry != nil {
+			mdFileModified = entry.ModifiedBefore(mdFile.MTime)
+		}
 		mdParentFileModified := false
 		if parentEntry != nil {
-			mdParentFileModified = CurrentIndex().Modified(parentEntry.RelativePath, mdFile.MTime)
+			mdParentFileModified = parentEntry.ModifiedAfter(mdFile.MTime)
+			// Ignore parent file that was modified after the current file
+			// if the current file had been added after.
+			if parentEntry.ModifiedBeforeLastIndexation(entry) {
+				mdParentFileModified = false
+			}
 		}
 		if !mdFileModified && !mdParentFileModified {
 			// Nothing changed = Nothing to parse
-			CurrentLogger().Info("👌 Markdown file was not modified since last pack file")
+			CurrentLogger().Debug("👌 Markdown file was not modified since last pack file")
 			return nil
 		}
 
@@ -343,7 +376,7 @@ func (r *Repository) Add(paths PathSpecs) error {
 			traversedPaths = append(traversedPaths, parsedMedia.RelativePath)
 
 			// Check if media has changed since last indexation
-			mediaFileModified := CurrentIndex().Modified(parsedMedia.RelativePath, parsedMedia.MTime)
+			mediaFileModified := CurrentIndex().ModifiedBefore(parsedMedia.RelativePath, parsedMedia.MTime)
 			if !mediaFileModified {
 				CurrentLogger().Info("👌 Media was not modified since last pack file")
 				// Media has not changed
@@ -375,7 +408,7 @@ func (r *Repository) Add(paths PathSpecs) error {
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Walk the index to identify old files
@@ -408,33 +441,37 @@ func (r *Repository) Add(paths PathSpecs) error {
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// We saved pack files on disk before starting a new transaction to keep it short
 	if err := db.BeginTransaction(); err != nil {
-		return err
+		return nil, err
 	}
 	if err := db.UpsertPackFiles(packFilesToUpsert...); err != nil {
-		return err
+		return nil, err
 	}
 	if err := db.DeletePackFiles(packFilesToDelete...); err != nil {
-		return err
+		return nil, err
 	}
 	if err := db.Index().Unstage(packFilesToDelete...); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Don't forget to commit
 	if err := db.CommitTransaction(); err != nil {
-		return err
+		return nil, err
 	}
 	// And to persist the index
 	if err := db.Index().Save(); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	var result AddResult
+	result.Upsert(packFilesToUpsert...)
+	result.Delete(packFilesToDelete...)
+
+	return &result, nil
 }
 
 // Reset implements the command `nt reset`
@@ -496,28 +533,34 @@ func (r *Repository) Commit() error {
 	idx := CurrentIndex()
 
 	if idx.NothingToCommit() {
-		return errors.New("nothing to commit (create/copy files and use \"nt add\" to track")
+		return errors.New("nothing to commit (create/copy files and use \"nt add\" to track)")
 	}
 
 	// Run hooks
-	for _, entry := range idx.Entries {
-		if entry.Staged && !entry.HasTombstone() {
-			packFile, err := idx.ReadPackFile(entry.PackFileOID)
-			if err != nil {
-				return err
-			}
-			for _, packObject := range packFile.PackObjects {
-				if packObject.Kind == "note" {
-					note := packObject.Read().(*Note)
-					if note.HasHooks() {
-						if err := note.RunHooks(nil, false); err != nil {
-							return err
-						}
+	idx.Walk(AnyPath, func(entry *IndexEntry, objects []*IndexObject, blobs []*IndexBlob) error {
+		CurrentLogger().Infof("Processing %s...\n", entry.RelativePath)
+		if !entry.Staged || entry.HasTombstone() {
+			// Run hooks only on staged, non-deleted entries
+			return nil
+		}
+
+		// Extract the notes from the pack file
+		packFile, err := idx.ReadPackFile(entry.PackFileOID)
+		if err != nil {
+			return err
+		}
+		for _, packObject := range packFile.PackObjects {
+			if packObject.Kind == "note" {
+				note := packObject.Read().(*Note)
+				if note.HasHooks() {
+					if err := note.RunHooks(nil, false); err != nil {
+						return err
 					}
 				}
 			}
 		}
-	}
+		return nil
+	})
 
 	return idx.Commit()
 }
@@ -606,7 +649,7 @@ func (r *Repository) Status(paths PathSpecs) (*StatusResult, error) {
 
 		// We ignore changes on parents
 
-		mdFileModified := CurrentIndex().Modified(relativePath, mdFile.MTime)
+		mdFileModified := CurrentIndex().ModifiedBefore(relativePath, mdFile.MTime)
 		if !mdFileModified {
 			// Nothing changed = Nothing to parse
 			return nil
@@ -618,7 +661,7 @@ func (r *Repository) Status(paths PathSpecs) (*StatusResult, error) {
 
 		if !index.Exists(relativePath) {
 			entryVerbs[relativePath] = "added"
-		} else if index.Modified(relativePath, mdFile.MTime) {
+		} else if index.ModifiedBefore(relativePath, mdFile.MTime) {
 			entryVerbs[relativePath] = "modified"
 		}
 
@@ -630,7 +673,7 @@ func (r *Repository) Status(paths PathSpecs) (*StatusResult, error) {
 				// Check if media has changed since last indexation
 				if !index.Exists(parsedMedia.RelativePath) {
 					entryVerbs[parsedMedia.RelativePath] = "added"
-				} else if index.Modified(parsedMedia.RelativePath, parsedMedia.MTime) {
+				} else if index.ModifiedBefore(parsedMedia.RelativePath, parsedMedia.MTime) {
 					entryVerbs[parsedMedia.RelativePath] = "modified"
 				}
 			}
@@ -942,7 +985,7 @@ func (r *Repository) diffUnstaged(paths PathSpecs) (ObjectDiffs, error) {
 
 		// We ignore changes on parents
 
-		mdFileModified := index.Modified(relativePath, mdFile.MTime)
+		mdFileModified := index.ModifiedBefore(relativePath, mdFile.MTime)
 		if !mdFileModified {
 			// Nothing changed = Nothing to parse
 			return nil
@@ -973,7 +1016,7 @@ func (r *Repository) diffUnstaged(paths PathSpecs) (ObjectDiffs, error) {
 			traversedEntryPaths = append(traversedEntryPaths, parsedMedia.RelativePath)
 
 			// Check if media has not changed
-			if !index.Modified(parsedMedia.RelativePath, parsedMedia.MTime) {
+			if !index.ModifiedBefore(parsedMedia.RelativePath, parsedMedia.MTime) {
 				continue
 			}
 

--- a/internal/core/repository.go
+++ b/internal/core/repository.go
@@ -538,7 +538,7 @@ func (r *Repository) Commit() error {
 
 	// Run hooks
 	idx.Walk(AnyPath, func(entry *IndexEntry, objects []*IndexObject, blobs []*IndexBlob) error {
-		CurrentLogger().Infof("Processing %s...\n", entry.RelativePath)
+		CurrentLogger().Debugf("Processing %s...\n", entry.RelativePath)
 		if !entry.Staged || entry.HasTombstone() {
 			// Run hooks only on staged, non-deleted entries
 			return nil

--- a/internal/core/repository_test.go
+++ b/internal/core/repository_test.go
@@ -269,7 +269,7 @@ func TestStatsInDB(t *testing.T) {
 	assert.Equal(t, 0, stats.Objects["link"])
 	assert.Equal(t, 0, stats.Objects["reminder"])
 
-	err = CurrentRepository().Add(AnyPath)
+	_, err = CurrentRepository().Add(AnyPath)
 	require.NoError(t, err)
 
 	stats, err = CurrentRepository().StatsInDB()

--- a/internal/core/testdata/TestLint/.nt/config.jsonnet
+++ b/internal/core/testdata/TestLint/.nt/config.jsonnet
@@ -39,6 +39,7 @@ local nt = import 'nt.libsonnet';
 
     Linter: {
         Rules: [
+            nt.LintRules.NoEmptyTitle(),
             nt.LintRules.NoDuplicateNoteTitle(),
             nt.LintRules.NoDuplicateSlug(),
             nt.LintRules.MinLinesBetweenNotes(2),

--- a/internal/core/testdata/TestLint/no-empty-title.md
+++ b/internal/core/testdata/TestLint/no-empty-title.md
@@ -1,0 +1,9 @@
+#
+
+## Note:
+
+There is no title.
+
+### Note: The title
+
+This is a title.

--- a/website/src/content/docs/developers/presentation.md
+++ b/website/src/content/docs/developers/presentation.md
@@ -495,3 +495,11 @@ func (r *Repository) Add(paths ...string) error {
     return nil
 }
 ```
+
+### How to log
+
+Use `CurrentLogger()` methods to log. The verbose level can be defined using the flags
+
+* `--v`: Info messages (= action with side-effects)
+* `--vv`: Debug messages (= action without side-effects)
+* `--vvv`: Trace messages (= information useful to debug)


### PR DESCRIPTION
## Motivation

Minor code changes following my tests trying to add and commit all my notes collected over the last years.

##  Changes

This pull request includes several changes to improve functionality and maintainability across the codebase. Key updates include refactoring the `CastDateFn` function to return strings instead of `time.Time`, introducing a `dryRun` flag for garbage collection commands, and modifying the repository's `Add` and `GC` methods to return additional information. Additionally, corresponding test cases have been updated to reflect these changes and ensure correctness.

### Refactoring and Functionality Updates:

* [`internal/core/attributes.go`](diffhunk://#diff-f6f56d64bb2544830ca1f1bc29bb55840121592cf5e8a465193ea2bac957c101L186-R224): Refactored `CastDateFn` to return strings instead of `time.Time`. This simplifies handling date formats by preserving the original string content while still validating against common date formats.
* [`cmd/nt/gc.go`](diffhunk://#diff-f156d7d90db3333bd34fec379345720c9876f7352ac3a13e1bb511b3abec1155R12): Added a `dryRun` flag to the garbage collection command, allowing users to simulate GC operations without making changes. Updated the `GC` method to accept this flag. [[1]](diffhunk://#diff-f156d7d90db3333bd34fec379345720c9876f7352ac3a13e1bb511b3abec1155R12) [[2]](diffhunk://#diff-f156d7d90db3333bd34fec379345720c9876f7352ac3a13e1bb511b3abec1155L21-R22) [[3]](diffhunk://#diff-476f6c60128b59bddd5d251a740c759a1fd5cc91b496b622406545ade5db3dd5R23)
