### PR TITLE
feat: support reversed and cloze deletions in flashcards

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
     "go.goroot": "/opt/homebrew/opt/go/libexec",
-    "go.testFlags": ["--tags", "fts5"]
+    "go.testFlags": ["--tags", "fts5", "-count=1"]
 }

--- a/internal/core/packfile.go
+++ b/internal/core/packfile.go
@@ -670,13 +670,14 @@ func NewPackFileFromParsedFile(parsedFile *ParsedFile) (*PackFile, error) {
 		objects = append(objects, note)
 
 		// Process the Flashcard
-		if parsedNote.Flashcard != nil {
-			parsedFlashcard := parsedNote.Flashcard
-			flashcard, err := NewOrExistingFlashcard(packFile, file, note, parsedFlashcard)
-			if err != nil {
-				return nil, err
+		if len(parsedNote.Flashcards) > 0 {
+			for _, parsedFlashcard := range parsedNote.Flashcards {
+				flashcard, err := NewOrExistingFlashcard(packFile, file, note, parsedFlashcard)
+				if err != nil {
+					return nil, err
+				}
+				objects = append(objects, flashcard)
 			}
-			objects = append(objects, flashcard)
 		}
 
 		// Process the Reminder(s)

--- a/internal/core/parser.go
+++ b/internal/core/parser.go
@@ -62,6 +62,10 @@ type ParsedFile struct {
 	Wikilinks []markdown.Wikilink // TODO still useful now that the method is exposed on markdown.Document?
 }
 
+func (p ParsedFile) String() string {
+	return fmt.Sprintf("ParsedFile %q", p.RelativePath)
+}
+
 // ParsedNote represents a single raw note inside a file.
 type ParsedNote struct {
 	Parent *ParsedNote
@@ -89,9 +93,13 @@ type ParsedNote struct {
 	Attributes     AttributeSet // Attributes defined in the note and inherited from the parent notes/files
 
 	// Extracted objects
-	Flashcard *ParsedFlashcard
-	GoLinks   []*ParsedGoLink
-	Reminders []*ParsedReminder
+	Flashcards []*ParsedFlashcard
+	GoLinks    []*ParsedGoLink
+	Reminders  []*ParsedReminder
+}
+
+func (p ParsedNote) String() string {
+	return fmt.Sprintf("ParsedNote %q in file %q at line %d", p.Title, p.RelativePath, p.Line)
 }
 
 type ParsedFlashcard struct {
@@ -104,6 +112,10 @@ type ParsedFlashcard struct {
 	// Fields in Markdown
 	Front markdown.Document
 	Back  markdown.Document
+}
+
+func (p ParsedFlashcard) String() string {
+	return fmt.Sprintf("ParsedFlashcard %q", p.ShortTitle)
 }
 
 type ParsedGoLink struct {
@@ -120,12 +132,20 @@ type ParsedGoLink struct {
 	GoName string
 }
 
+func (p ParsedGoLink) String() string {
+	return fmt.Sprintf("ParsedGoLink %q", p.GoName)
+}
+
 type ParsedReminder struct {
 	// Description in Markdown of the reminder (ex: the line)
 	Description markdown.Document
 
 	// Tag value containig the formula to determine the next occurence
 	Tag string `yaml:"tag"`
+}
+
+func (p ParsedReminder) String() string {
+	return fmt.Sprintf("ParsedReminder `#%s`", p.Tag)
 }
 
 type ParsedMedia struct {
@@ -151,6 +171,10 @@ type ParsedMedia struct {
 
 	// Line number where the link present.
 	Line int
+}
+
+func (p ParsedMedia) String() string {
+	return fmt.Sprintf("ParsedMedia %q", p.RawPath)
 }
 
 func (p *ParsedMedia) FileMTime() time.Time {

--- a/internal/core/parser_test.go
+++ b/internal/core/parser_test.go
@@ -88,7 +88,7 @@ func TestParseFileWithTestdata(t *testing.T) {
 					"tags":   []string{"thinking"},
 				}, noteNote.Attributes)
 				// No subobjects
-				assert.Nil(t, noteNote.Flashcard)
+				assert.Len(t, noteNote.Flashcards, 0)
 				assert.Len(t, noteNote.GoLinks, 0)
 				assert.Len(t, noteNote.Reminders, 0)
 
@@ -107,8 +107,8 @@ func TestParseFileWithTestdata(t *testing.T) {
 				// Check "Flashcard: Commonplace Book"
 				noteCommomplace, ok := file.FindNoteByShortTitle("Commonplace Book")
 				require.True(t, ok)
-				require.NotNil(t, noteCommomplace.Flashcard)
-				flashcardCommonplace := noteCommomplace.Flashcard
+				require.Len(t, noteCommomplace.Flashcards, 1)
+				flashcardCommonplace := noteCommomplace.Flashcards[0]
 				assert.Equal(t, "Commonplace Book", flashcardCommonplace.ShortTitle.String())
 				assert.Equal(t, "(Thinking) What are **commonplace books**?", flashcardCommonplace.Front.String())
 				assert.Equal(t, "A tool to compile knowledge, usually by writing information into books.", flashcardCommonplace.Back.String())
@@ -220,6 +220,93 @@ func TestParseFileWithTestdata(t *testing.T) {
 }
 
 func TestParseFileWithTempdir(t *testing.T) {
+
+	t.Run("Nested Flashcards", func(t *testing.T) {
+		root := core.SetUpRepositoryFromTempDir(t)
+
+		// Create a file with nested flashcards at different levels.
+		// We will check that the flashcards are correctly extracted without including sub-notes and siblings sections.
+		core.MustWriteFile(t, "learning.md", text.UnescapeTestContent(`
+---
+tags: learning
+---
+
+# Learning
+
+## Note: Rote Memorization
+
+Rote memorization is a technique of learning by repetition.
+
+### Flashcard: Rote Memorization
+
+(Learning) What is **rote memorization**?
+
+---
+
+A technique of **learning by repetition**.
+
+### Advantages
+
+* It is a simple technique.
+* It is effective for short-term memory.
+
+### Drawbacks
+
+* It is not effective for long-term memory.
+* It does not promote understanding of the material.
+
+#### Flashcard: Rote Memorization Limitations
+
+(Learning) What are the **limitations of rote memorization**?
+
+---
+
+It is not effective for **long-term memory** and does not promote **understanding of the material**.
+
+## Note: Spaced Repetition
+
+Spaced repetition is a technique of learning by reviewing material at increasing intervals.
+
+### Flashcard: Spaced Repetition
+
+(Learning) What is **spaced repetition**?
+
+---
+
+A technique of **learning by reviewing material at increasing intervals**.
+
+### Flashcard: Spaced Repetition History
+
+(Learning) [[c1::Hermann Ebbinghaus::person]] invented **spaced repetition**
+`))
+
+		md := markdown.MustParseFile(filepath.Join(root, "learning.md"))
+		index, err := core.ParseFile(md, nil)
+		require.NoError(t, err)
+
+		require.Len(t, index.Notes, 6)
+
+		note1 := index.Notes[0]
+		note2 := index.Notes[1]
+		note3 := index.Notes[2]
+		note4 := index.Notes[3]
+		note5 := index.Notes[4]
+		note6 := index.Notes[5]
+
+		assert.Equal(t, "Note: Rote Memorization", note1.Title.String())
+		assert.Equal(t, "Flashcard: Rote Memorization", note2.Title.String())
+		assert.Equal(t, "Flashcard: Rote Memorization Limitations", note3.Title.String())
+		assert.Equal(t, "Note: Spaced Repetition", note4.Title.String())
+		assert.Equal(t, "Flashcard: Spaced Repetition", note5.Title.String())
+		assert.Equal(t, "Flashcard: Spaced Repetition History", note6.Title.String())
+
+		assert.Equal(t, "Rote memorization is a technique of learning by repetition.", note1.Body.String())
+		assert.Equal(t, "(Learning) What is **rote memorization**?\n\n---\n\nA technique of **learning by repetition**.", note2.Body.String())
+		assert.Equal(t, "(Learning) What are the **limitations of rote memorization**?\n\n---\n\nIt is not effective for **long-term memory** and does not promote **understanding of the material**.", note3.Body.String())
+		assert.Equal(t, "Spaced repetition is a technique of learning by reviewing material at increasing intervals.", note4.Body.String())
+		assert.Equal(t, "(Learning) What is **spaced repetition**?\n\n---\n\nA technique of **learning by reviewing material at increasing intervals**.", note5.Body.String())
+		assert.Equal(t, "(Learning) [[c1::Hermann Ebbinghaus::person]] invented **spaced repetition**", note6.Body.String())
+	})
 
 	t.Run("Attributes & Tags", func(t *testing.T) {
 		// Test attributes and tags defined in Front Matter and in notes

--- a/internal/core/preprocessors.go
+++ b/internal/core/preprocessors.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -183,23 +184,90 @@ func GeneratorPreprocessor(file *ParsedFile, note *ParsedNote) ([]*ParsedNote, e
 
 // FlashcardExtractorPreprocessor extracts the flashcard to enrich a note. This preprocessor returns the same input note.
 func FlashcardExtractorPreprocessor(file *ParsedFile, note *ParsedNote) ([]*ParsedNote, error) {
-	// Only front/back to parse
 	parts := note.Body.SplitByHorizontalRules()
-	if len(parts) < 2 {
-		return nil, errors.New("missing flashcard separator")
+
+	if len(parts) == 1 {
+		return flashcardWithClozeDeletionExtractor(file, note)
 	}
+
+	// Not possible to have more than 2 parts
 	if len(parts) > 2 {
 		return nil, errors.New("too many flashcard separator")
 	}
+	// 2 parts are required for cards (except for cloze deletions)
+	if len(parts) < 2 {
+		return nil, errors.New("missing flashcard separator")
+	}
+
 	front := parts[0]
 	back := parts[1]
 
-	// Simply enrich the current note with the flashcard
-	note.Flashcard = &ParsedFlashcard{
+	note.Flashcards = append(note.Flashcards, &ParsedFlashcard{
 		ShortTitle: note.ShortTitle,
 		Slug:       note.Slug,
 		Front:      front,
 		Back:       back,
+	})
+
+	if note.NoteTags.Includes("reversed") {
+		note.Flashcards = append(note.Flashcards, &ParsedFlashcard{
+			ShortTitle: note.ShortTitle,
+			Slug:       note.Slug + "-reversed",
+			Front:      back,
+			Back:       front,
+		})
+	}
+
+	return []*ParsedNote{note}, nil
+}
+
+// flashcardWithClozeDeletionExtractor extracts flashcards using the cloze deletion syntax.
+func flashcardWithClozeDeletionExtractor(_ *ParsedFile, note *ParsedNote) ([]*ParsedNote, error) {
+	body := note.Body.String()
+
+	// We use Anki syntax for cloze deletions using brackets instead of curly braces.
+	// Ex: [[c1::This is a cloze deletion::optional hint]]
+	// See https://docs.ankiweb.net/editing.html#cloze-deletion
+	// Curly braces are often used in programming languages (ex: Astro uses them for variables).
+	// Even if there is no support for variables in _The NoteWriter_, we use brackets to avoid
+	// future conflicts.
+
+	clozePattern := regexp.MustCompile(`\[\[(\w+)::([^\]:]+?)(?:::(.+?))?\]\]`)
+	if !clozePattern.MatchString(body) {
+		return nil, errors.New("missing cloze deletion syntax")
+	}
+
+	// Find all unique cloze groups
+	clozes := clozePattern.FindAllStringSubmatch(body, -1)
+	groupSet := []string{} // Use a set to keep group names in the order of their first appearance
+	for _, sub := range clozes {
+		if !slices.Contains(groupSet, sub[1]) {
+			groupSet = append(groupSet, sub[1])
+		}
+	}
+
+	// For each group, create a flashcard
+	for _, group := range groupSet {
+		front := clozePattern.ReplaceAllStringFunc(body, func(m string) string {
+			sub := clozePattern.FindStringSubmatch(m)
+			if sub[1] == group {
+				if sub[3] != "" {
+					return fmt.Sprintf("[%s]", sub[3])
+				}
+				return "[...]"
+			}
+			return sub[2]
+		})
+		back := clozePattern.ReplaceAllStringFunc(body, func(m string) string {
+			sub := clozePattern.FindStringSubmatch(m)
+			return sub[2]
+		})
+		note.Flashcards = append(note.Flashcards, &ParsedFlashcard{
+			ShortTitle: note.ShortTitle,
+			Slug:       note.Slug,
+			Front:      markdown.Document(front),
+			Back:       markdown.Document(back),
+		})
 	}
 
 	return []*ParsedNote{note}, nil

--- a/internal/core/processors_test.go
+++ b/internal/core/processors_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/julien-sobczak/the-notewriter/internal/core"
 	"github.com/julien-sobczak/the-notewriter/internal/markdown"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractDateFromTitle(t *testing.T) {
@@ -108,4 +109,189 @@ func TestQuoteRewriterPreprocessor(t *testing.T) {
 			assert.Equal(t, tt.expectedBody, resultNotes[0].Body.String())
 		})
 	}
+}
+
+func TestFlashcardExtractorPreprocessor(t *testing.T) {
+
+	t.Run("Basic syntax", func(t *testing.T) {
+		file := &core.ParsedFile{}
+		note := &core.ParsedNote{
+			Title:      markdown.Document("Flashcard: Basic"),
+			ShortTitle: markdown.Document("Basic"),
+			Slug:       "flashcard-basic",
+			Body: markdown.Document(`
+Front
+
+---
+
+Back
+`),
+		}
+		notes, err := core.FlashcardExtractorPreprocessor(file, note)
+		require.NoError(t, err)
+
+		// We still have the original note
+		require.Len(t, notes, 1)
+		note = notes[0]
+
+		// With a flashcard extracted
+		require.Len(t, note.Flashcards, 1)
+		flashcard := note.Flashcards[0]
+		assert.Equal(t, "Basic", flashcard.ShortTitle.String())
+		assert.Equal(t, "flashcard-basic", flashcard.Slug)
+		assert.Equal(t, "Front", flashcard.Front.String())
+		assert.Equal(t, "Back", flashcard.Back.String())
+	})
+
+	t.Run("Basic with reversed syntax", func(t *testing.T) {
+		file := &core.ParsedFile{}
+		note := &core.ParsedNote{
+			Title:      markdown.Document("Flashcard: Basic"),
+			ShortTitle: markdown.Document("Basic"),
+			Slug:       "flashcard-basic",
+			NoteTags:   []string{"reversed"},
+			Body: markdown.Document(`
+Front
+
+---
+
+Back
+`),
+		}
+		notes, err := core.FlashcardExtractorPreprocessor(file, note)
+		require.NoError(t, err)
+
+		// We still have the original note
+		require.Len(t, notes, 1)
+		note = notes[0]
+
+		// With two flashcards extracted
+		require.Len(t, note.Flashcards, 2)
+		flashcard := note.Flashcards[0]
+		flashcardReversed := note.Flashcards[1]
+		assert.Equal(t, &core.ParsedFlashcard{
+			ShortTitle: "Basic",
+			Slug:       "flashcard-basic",
+			Front:      "Front",
+			Back:       "Back",
+		}, flashcard)
+		assert.Equal(t, &core.ParsedFlashcard{
+			ShortTitle: "Basic",
+			Slug:       "flashcard-basic-reversed",
+			Front:      "Back",
+			Back:       "Front",
+		}, flashcardReversed)
+	})
+
+	t.Run("Cloze deletion syntax", func(t *testing.T) {
+		file := &core.ParsedFile{}
+		note := &core.ParsedNote{
+			Title:      markdown.Document("Flashcard: Cloze Deletion"),
+			ShortTitle: markdown.Document("Cloze Deletion"),
+			Slug:       "flashcard-cloze-deletion",
+			Body:       markdown.Document(`Canberra was founded in **[[c1::1913]]**.`),
+		}
+		notes, err := core.FlashcardExtractorPreprocessor(file, note)
+		require.NoError(t, err)
+
+		// We still have the original note
+		require.Len(t, notes, 1)
+		note = notes[0]
+
+		// A flashcard must have been generated from the cloze deletion
+		require.Len(t, note.Flashcards, 1)
+		flashcard := note.Flashcards[0]
+		assert.Equal(t, &core.ParsedFlashcard{
+			ShortTitle: "Cloze Deletion",
+			Slug:       "flashcard-cloze-deletion",
+			Front:      "Canberra was founded in **[...]**.",
+			Back:       "Canberra was founded in **1913**.",
+		}, flashcard)
+	})
+
+	t.Run("Cloze deletion with hint syntax", func(t *testing.T) {
+		file := &core.ParsedFile{}
+		note := &core.ParsedNote{
+			Title:      markdown.Document("Flashcard: Cloze Deletion"),
+			ShortTitle: markdown.Document("Cloze Deletion"),
+			Slug:       "flashcard-cloze-deletion",
+			Body:       markdown.Document(`Canberra was founded in [[c1::1913::year]].`),
+		}
+		notes, err := core.FlashcardExtractorPreprocessor(file, note)
+		require.NoError(t, err)
+
+		// We still have the original note
+		require.Len(t, notes, 1)
+		note = notes[0]
+
+		// A flashcard must have been generated from the cloze deletion
+		require.Len(t, note.Flashcards, 1)
+		flashcard := note.Flashcards[0]
+		assert.Equal(t, &core.ParsedFlashcard{
+			ShortTitle: "Cloze Deletion",
+			Slug:       "flashcard-cloze-deletion",
+			Front:      "Canberra was founded in [year].",
+			Back:       "Canberra was founded in 1913.",
+		}, flashcard)
+	})
+
+	t.Run("Multiple cloze deletions in same group", func(t *testing.T) {
+		file := &core.ParsedFile{}
+		note := &core.ParsedNote{
+			Title:      markdown.Document("Flashcard: Cloze Deletion"),
+			ShortTitle: markdown.Document("Cloze Deletion"),
+			Slug:       "flashcard-cloze-deletion",
+			Body:       markdown.Document(`[[c1::Canberra::city]] was founded in [[c1::1913]].`),
+		}
+		notes, err := core.FlashcardExtractorPreprocessor(file, note)
+		require.NoError(t, err)
+
+		// We still have the original note
+		require.Len(t, notes, 1)
+		note = notes[0]
+
+		// A flashcard must have been generated from the cloze deletion
+		require.Len(t, note.Flashcards, 1)
+		flashcard := note.Flashcards[0]
+		assert.Equal(t, &core.ParsedFlashcard{
+			ShortTitle: "Cloze Deletion",
+			Slug:       "flashcard-cloze-deletion",
+			Front:      "[city] was founded in [...].",
+			Back:       "Canberra was founded in 1913.",
+		}, flashcard)
+	})
+
+	t.Run("Multiple cloze deletions in different groups", func(t *testing.T) {
+		file := &core.ParsedFile{}
+		note := &core.ParsedNote{
+			Title:      markdown.Document("Flashcard: Cloze Deletion"),
+			ShortTitle: markdown.Document("Cloze Deletion"),
+			Slug:       "flashcard-cloze-deletion",
+			Body:       markdown.Document(`[[c1::Canberra::city]] was founded in [[c2::1913]].`),
+		}
+		notes, err := core.FlashcardExtractorPreprocessor(file, note)
+		require.NoError(t, err)
+
+		// We still have the original note
+		require.Len(t, notes, 1)
+		note = notes[0]
+
+		// Several flashcards must have been generated from the cloze deletions
+		require.Len(t, note.Flashcards, 2)
+		flashcard1 := note.Flashcards[0]
+		flashcard2 := note.Flashcards[1]
+		assert.Equal(t, &core.ParsedFlashcard{
+			ShortTitle: "Cloze Deletion",
+			Slug:       "flashcard-cloze-deletion",
+			Front:      "[city] was founded in 1913.",
+			Back:       "Canberra was founded in 1913.",
+		}, flashcard1)
+		assert.Equal(t, &core.ParsedFlashcard{
+			ShortTitle: "Cloze Deletion",
+			Slug:       "flashcard-cloze-deletion",
+			Front:      "Canberra was founded in [...].",
+			Back:       "Canberra was founded in 1913.",
+		}, flashcard2)
+	})
+
 }


### PR DESCRIPTION
This pull request introduces enhancements to the flashcard management. The most important changes include transitioning from single flashcard objects to handling multiple flashcards per note, supporting cloze deletion syntax similar to Anki.

### Flashcard System Enhancements:

* **Support for Multiple Flashcards per Note**: The `ParsedNote` structure now supports multiple flashcards (`Flashcards` array) instead of a single flashcard (`Flashcard`). This allows notes to contain multiple flashcards and processes them accordingly. (`internal/core/parser.go`, [[1]](diffhunk://#diff-3fc98fe0e096c33f45b4aeb0e14d21dd32b870f56d09f6c33d9a7443ece6bd6cL92-R104); `internal/core/packfile.go`, [[2]](diffhunk://#diff-c1e1794dfdfe24aa4887926042d3f5ef6a1cf3e8c7c6fa087e2ff58da37f74f8L673-R681)
* **Cloze Deletion Syntax for Flashcards**: Added support for cloze deletion syntax (e.g., `[[c1::text::hint]]`) to extract flashcards directly from note bodies. This feature includes handling multiple cloze deletions within the same or different groups. (`internal/core/preprocessors.go`)
* **Reversed Flashcards**: Introduced functionality to create reversed flashcards when the `reversed` tag is present in the note.

