### PR TITLE
feat: support multiple remotes in configuration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,12 +2,16 @@
 
 ## TODO: Backlog
 
+* [ ] Add file `operation-graph` in `.nt/` (similar to `commit-graph` even if the graph will be linear)
+* [ ] Push/Pull operations too
+* [ ] Implement proposal `RepositoryTest`
+* [ ] Create remote for [Filen](https://filen.io/pricing) => Go SDK is not mature... wait&see 🤞
 * [ ] Rework documentation `linter.md` and introduce a new `config.md`
 * [ ] Add tests for `GeneratorPreprocessor`
 
 ## TODO: Bug Fixes
 
-* [ ] TODO
+* TODO
 
 ## TODO: Sprint
 

--- a/cmd/nt/cat_file.go
+++ b/cmd/nt/cat_file.go
@@ -21,12 +21,8 @@ func init() {
 var catFileCmd = &cobra.Command{
 	Use:   "cat-file",
 	Short: "Display a repository file",
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) > 1 {
-			fmt.Println("Too many arguments. You can only have one which must be a wikilink or an OID")
-			os.Exit(1)
-		}
-
 		arg := args[0]
 
 		if oid := oid.ParseOrNil(arg); !oid.IsNil() {

--- a/cmd/nt/go.go
+++ b/cmd/nt/go.go
@@ -16,12 +16,8 @@ func init() {
 var goCmd = &cobra.Command{
 	Use:   "go",
 	Short: "Redirect to a Go link",
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) > 1 {
-			fmt.Println("Too many arguments. You can only have one which must be a go link name")
-			os.Exit(1)
-		}
-
 		goName := args[0]
 
 		link, err := core.CurrentRepository().FindGoLinkByGoName(goName)

--- a/cmd/nt/hook.go
+++ b/cmd/nt/hook.go
@@ -20,12 +20,8 @@ var runHookCmd = &cobra.Command{
 	Use:   "run-hook",
 	Short: "Run hooks",
 	Long:  `Run all hooks on a single note.`,
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) > 1 {
-			fmt.Println("Too many arguments. You can only have one which must be a wikilink")
-			os.Exit(1)
-		}
-
 		// Process argument(s)
 		wikilink := args[0]
 

--- a/cmd/nt/pull.go
+++ b/cmd/nt/pull.go
@@ -18,14 +18,16 @@ var pullCmd = &cobra.Command{
 	Use:   "pull",
 	Short: "Pull remote",
 	Long:  `Pull remote to retrieve new objects and update local database.`,
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckConfig()
-		if core.CurrentDB().Origin() == nil {
-			fmt.Println("There is no remote currently configured.")
+		remoteName := args[0]
+		if core.CurrentDB().Remote(remoteName) == nil {
+			fmt.Printf("There is no remote %q currently configured.\n", remoteName)
 			fmt.Println("Please specify one in .nt/config")
 			os.Exit(1)
 		}
-		err := core.CurrentRepository().Pull(interactive, force)
+		err := core.CurrentRepository().Pull(remoteName, interactive, force)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/nt/push.go
+++ b/cmd/nt/push.go
@@ -18,16 +18,18 @@ var pushCmd = &cobra.Command{
 	Use:   "push",
 	Short: "Push to remote",
 	Long:  `Push to remote new objects.`,
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckConfig()
 
-		if core.CurrentDB().Origin() == nil {
-			fmt.Println("There is no remote currently configured.")
+		remoteName := args[0]
+		if core.CurrentDB().Remote(remoteName) == nil {
+			fmt.Printf("There is no remote %q currently configured.\n", remoteName)
 			fmt.Println("Please specify one in .nt/config")
 			os.Exit(1)
 		}
 
-		err := core.CurrentRepository().Push(interactive, force)
+		err := core.CurrentRepository().Push(remoteName, interactive, force)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/internal/core/attributes.go
+++ b/internal/core/attributes.go
@@ -171,16 +171,14 @@ var CastBoolFn CastFn[bool] = func(value any) (bool, bool) {
 		return value.(bool), true
 	}
 	// Only convert from string to bool
-	if IsString(value) {
-		if value == "true" {
-			return true, true
-		} else if value == "false" {
-			return false, true
-		} else {
-			return false, false
-		}
+	switch value {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
 	}
-	return false, false
 }
 
 var CastDateFn CastFn[string] = func(v any) (string, bool) {

--- a/internal/core/commands_test.go
+++ b/internal/core/commands_test.go
@@ -283,9 +283,12 @@ func TestCommandPushPull(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestMinimal")
 		// Configure origin
 		origin := t.TempDir()
-		CurrentConfig().ConfigFile.Remote = ConfigRemote{
-			Type: "fs",
-			Dir:  origin,
+		CurrentConfig().ConfigFile.Remotes = []ConfigRemote{
+			{
+				Name: "origin",
+				Type: "fs",
+				Dir:  origin,
+			},
 		}
 
 		// Push
@@ -294,7 +297,7 @@ func TestCommandPushPull(t *testing.T) {
 		err = CurrentRepository().Commit()
 		require.NoError(t, err)
 		require.NoError(t, CurrentConfig().Save()) // Simulate Cobra PostRun logic
-		err = CurrentRepository().Push(false, false)
+		err = CurrentRepository().Push("origin", false, false)
 		require.NoError(t, err)
 
 		// Check origin
@@ -315,11 +318,14 @@ func TestCommandPushPull(t *testing.T) {
 		// Force a new temp repository
 		SetUpRepositoryFromGoldenDirNamed(t, "TestMinimal")
 		// but with the same origin
-		CurrentConfig().ConfigFile.Remote = ConfigRemote{
-			Type: "fs",
-			Dir:  origin,
+		CurrentConfig().ConfigFile.Remotes = []ConfigRemote{
+			{
+				Name: "origin",
+				Type: "fs",
+				Dir:  origin,
+			},
 		}
-		err = CurrentRepository().Pull(false, false)
+		err = CurrentRepository().Pull("origin", false, false)
 		require.NoError(t, err)
 		// We must now have the same number of entries, objects and blobs as pushed before
 		assert.Equal(t, countEntries, len(CurrentIndex().Entries))
@@ -331,9 +337,12 @@ func TestCommandPushPull(t *testing.T) {
 		SetUpRepositoryFromGoldenDirNamed(t, "TestMinimal")
 		// Configure origin
 		origin := t.TempDir()
-		CurrentConfig().ConfigFile.Remote = ConfigRemote{
-			Type: "fs",
-			Dir:  origin,
+		CurrentConfig().ConfigFile.Remotes = []ConfigRemote{
+			{
+				Name: "origin",
+				Type: "fs",
+				Dir:  origin,
+			},
 		}
 
 		// Commit
@@ -357,10 +366,10 @@ Guido van Rossum
 		require.NoError(t, err)
 
 		// Push
-		err = CurrentRepository().Push(false, false)
+		err = CurrentRepository().Push("origin", false, false)
 		require.ErrorContains(t, err, "changes not commited")
 		// Pull
-		err = CurrentRepository().Pull(false, false)
+		err = CurrentRepository().Pull("origin", false, false)
 		require.ErrorContains(t, err, "changes not commited")
 	})
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -110,7 +110,7 @@ type ConfigFile struct {
 	Types      ConfigTypes      `json:"types"`
 
 	// Remotes
-	Remote ConfigRemote `json:"remote"` // IMPROVEMENT Support multiple remotes
+	Remotes []ConfigRemote `json:"remote"` // IMPROVEMENT Support multiple remotes
 
 	// Predefined searches
 	Searches map[string]*ConfigSearch `json:"searches"`
@@ -173,11 +173,11 @@ type ConfigAttribute struct {
 
 type ConfigType struct {
 	Name               string   `json:"name"`
-	Pattern            string   `json:"pattern,omitempty"`   // Regex to detect Markdown headings matching the type
-	Preprocessors      []string `json:"preprocessors"`       // Additional logic to run after parsing a note
+	Pattern            string   `json:"pattern,omitempty"`  // Regex to detect Markdown headings matching the type
+	Preprocessors      []string `json:"preprocessors"`      // Additional logic to run after parsing a note
 	RequiredAttributes []string `json:"requiredAttributes"` // List of mandatory attributes
 	OptionalAttributes []string `json:"optionalAttributes"` // List of optional attributes
-	Hooks              []string `json:"hooks"`               // List of hooks to run on this type of note
+	Hooks              []string `json:"hooks"`              // List of hooks to run on this type of note
 	// IMPROVEMENT refactor to Attributes []ConfigTypeAttribute with an attribute `required` (= more extensible)
 }
 type ConfigLinter struct {
@@ -196,6 +196,7 @@ type ConfigMedias struct {
 	Preset   string `json:"preset"`
 }
 type ConfigRemote struct {
+	Name string `json:"name"` // Name as specified when running commands
 	Type string `json:"type"` // fs or s3
 	// fs-specific attributes
 	Dir string `json:"dir,omitempty"`
@@ -251,26 +252,6 @@ func (f *ConfigFile) SupportExtension(path string) bool {
 		}
 	}
 	return false
-}
-
-// ConfigureFSRemote defines a local remote using the file system.
-func (f *ConfigFile) ConfigureFSRemote(dir string) *ConfigFile {
-	f.Remote = ConfigRemote{
-		Type: "fs",
-		Dir:  dir,
-	}
-	return f
-}
-
-// ConfigureS3Remote defines a remote using a S3 backend.
-func (f *ConfigFile) ConfigureS3Remote(bucketName, accessKey, secretKey string) *ConfigFile {
-	f.Remote = ConfigRemote{
-		Type:       "s3",
-		BucketName: bucketName,
-		AccessKey:  accessKey,
-		SecretKey:  secretKey,
-	}
-	return f
 }
 
 func (c ConfigAttribute) String() string {

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -37,12 +37,10 @@ var (
 type DB struct {
 	// .nt/index
 	index *Index
-	// .nt/refs/*
-	refs map[string]string
-	// .nt/refs/origin
-	origin remote.Remote
 	// .nt/database.sql
 	client *sql.DB
+	// Remote references
+	remotes map[string]remote.Remote
 
 	// In-progress transaction
 	tx *sql.Tx
@@ -53,13 +51,9 @@ func CurrentDB() *DB {
 		// Load index
 		index := MustReadIndex()
 
-		// Load refs
-		refs := MustReadRefs()
-
 		// Create the database
 		dbSingleton = &DB{
 			index: index,
-			refs:  refs,
 		}
 	})
 	return dbSingleton
@@ -100,31 +94,6 @@ func (db *DB) initClient() *sql.DB {
 		}
 	})
 	return dbSingleton.client
-}
-
-func MustReadRefs() map[string]string {
-	refs := make(map[string]string)
-	refdir := CurrentRepository().GetAbsolutePath(".nt/refs")
-	files, err := os.ReadDir(refdir)
-	if os.IsNotExist(err) {
-		// No existing refs (occurs before the first commit)
-		return refs
-	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to read refs under .nt/refs directory: %v", err)
-		os.Exit(1)
-	}
-	for _, file := range files {
-		if !file.IsDir() {
-			data, err := os.ReadFile(filepath.Join(refdir, file.Name()))
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Unable to read .nt/refs/%s directory: %v", file.Name(), err)
-				os.Exit(1)
-			}
-			refs[file.Name()] = strings.TrimSpace(string(data))
-		}
-	}
-	return refs
 }
 
 func (db *DB) Close() error {
@@ -328,46 +297,65 @@ func (db *DB) DeleteBlobOnDisk(blob BlobRef) error {
  * Remote Management
  */
 
-// Origin returns the origin implementation based on the optional configured type.
-func (db *DB) Origin() remote.Remote {
+func (db *DB) Remote(name string) remote.Remote {
 	dbRemoteOnce.Do(func() {
-		config := CurrentConfig()
-		configRemote := config.ConfigFile.Remote
-		if configRemote.Type == "" {
-			return
+		db.remotes = make(map[string]remote.Remote)
+	})
+
+	config := CurrentConfig()
+	configRemotes := config.ConfigFile.Remotes
+	for _, configRemote := range configRemotes {
+		if configRemote.Name != name {
+			continue
 		}
-		switch configRemote.Type {
-		case "fs":
-			remote, err := remote.NewFS(configRemote.Dir)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Unable to init FS remote: %v\n", err)
-				os.Exit(1)
-			}
-			db.origin = remote
-		case "s3":
-			// Read sensitive credentials from environment variables
-			accessKey := os.Getenv("NT_S3_ACCESS_KEY")
-			if accessKey == "" {
-				fmt.Fprintf(os.Stderr, "Missing environment variable NT_S3_ACCESS_KEY\n")
-				os.Exit(1)
-			}
-			secretKey := os.Getenv("NT_S3_SECRET_KEY")
-			if secretKey == "" {
-				fmt.Fprintf(os.Stderr, "Missing environment variable NT_S3_SECRET_KEY\n")
-				os.Exit(1)
-			}
-			remote, err := remote.NewS3WithCredentials(configRemote.Endpoint, configRemote.BucketName, accessKey, secretKey, configRemote.Secure)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Unable to init S3 remote: %v\n", err)
-				os.Exit(1)
-			}
-			db.origin = remote
-		default:
-			fmt.Fprintf(os.Stderr, "Unknow remote type %q\n", configRemote.Type)
+		if remote, ok := db.remotes[name]; ok {
+			return remote // Already initialized
+		}
+		remote := db.initRemote(configRemote)
+		db.remotes[name] = remote
+		return remote
+	}
+	return nil // No remote found
+}
+
+// Origin returns the optional remote "origin".
+func (db *DB) Origin() remote.Remote {
+	return db.Remote("origin")
+}
+
+func (db *DB) initRemote(config ConfigRemote) remote.Remote {
+	// Initialize the remote
+	switch config.Type {
+	case "fs":
+		remote, err := remote.NewFS(config.Dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to init FS remote: %v\n", err)
 			os.Exit(1)
 		}
-	})
-	return db.origin
+		return remote
+	case "s3":
+		// Read sensitive credentials from environment variables
+		accessKey := os.Getenv("NT_S3_ACCESS_KEY")
+		if accessKey == "" {
+			fmt.Fprintf(os.Stderr, "Missing environment variable NT_S3_ACCESS_KEY\n")
+			os.Exit(1)
+		}
+		secretKey := os.Getenv("NT_S3_SECRET_KEY")
+		if secretKey == "" {
+			fmt.Fprintf(os.Stderr, "Missing environment variable NT_S3_SECRET_KEY\n")
+			os.Exit(1)
+		}
+		remote, err := remote.NewS3WithCredentials(config.Endpoint, config.BucketName, accessKey, secretKey, config.Secure)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to init S3 remote: %v\n", err)
+			os.Exit(1)
+		}
+		return remote
+	default:
+		fmt.Fprintf(os.Stderr, "Unknow remote type %q\n", config.Type)
+		os.Exit(1)
+	}
+	return nil // Unreachable
 }
 
 // Diff show the changes in the staging area.
@@ -479,12 +467,6 @@ func (db *DB) GC(dryRun bool) (*GCResult, error) {
 }
 
 /* Utility */
-
-// Ref returns the commit OID for the given ref
-func (db *DB) Ref(name string) (string, bool) {
-	value, ok := db.refs[name]
-	return value, ok
-}
 
 // BlobExists checks if a blob exists locally.
 func (db *DB) BlobExists(oid oid.OID) bool {

--- a/internal/core/repository.go
+++ b/internal/core/repository.go
@@ -724,7 +724,7 @@ func (r *Repository) Status(paths PathSpecs) (*StatusResult, error) {
 }
 
 // Push pushes new objects remotely.
-func (r *Repository) Push(interactive, force bool) error {
+func (r *Repository) Push(remoteName string, interactive, force bool) error {
 	CurrentConfig().DryRun = true
 
 	// Implementation: We don't use a locking mechanism to prevent another repository to push at the same time.
@@ -734,7 +734,7 @@ func (r *Repository) Push(interactive, force bool) error {
 		return errors.New("changes not commited (commit first and retry)")
 	}
 
-	origin := CurrentDB().Origin()
+	origin := CurrentDB().Remote(remoteName)
 	if origin == nil {
 		return errors.New("no remote found")
 	}
@@ -830,7 +830,7 @@ func (r *Repository) Push(interactive, force bool) error {
 }
 
 // Pull retrieves remote objects.
-func (r *Repository) Pull(interactive, force bool) error {
+func (r *Repository) Pull(remoteName string, interactive, force bool) error {
 	CurrentConfig().DryRun = false
 
 	// Implementation: We don't use a locking mechanism to prevent another repository to push at the same time.
@@ -840,7 +840,7 @@ func (r *Repository) Pull(interactive, force bool) error {
 		return errors.New("changes not commited (commit first and retry)")
 	}
 
-	origin := CurrentDB().Origin()
+	origin := CurrentDB().Remote(remoteName)
 	if origin == nil {
 		return errors.New("no remote found")
 	}


### PR DESCRIPTION
Using multiple remotes may be interesting in the future:

- Push to a S3-like storage solution for backup
- Push to a local smartphone using Bluetooth/Wifi
- Push some notebooks to NotebookLM (or a similar solution)

This MR only updates the JSON configuration file format to support an array of remotes.