### PR TITLE
feat: render a random quote by default

### DIFF
--- a/cmd/nt/nt.go
+++ b/cmd/nt/nt.go
@@ -26,6 +26,13 @@ var rootCmd = &cobra.Command{
 	Use:   "nt",
 	Short: "The NoteWriter is a file-based note management tool",
 	Long:  `A Powerful and Flexible Note Management Tool using only Markdown files.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Default behavior: show a random quote
+		if err := showRandomQuote(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if cmd.Name() != "init" {
 			// Ignore when configuration doesn't still exist
@@ -75,6 +82,28 @@ func Execute() {
 		<-sigs
 		core.CurrentRepository().Close()
 	}()
+}
+
+/* Quote Display Functions */
+
+// showRandomQuote displays a random quote from the database
+func showRandomQuote() error {
+	quote, err := core.CurrentRepository().GetRandomQuote()
+	if err != nil {
+		return err
+	}
+	
+	if quote == nil {
+		fmt.Println("No quotes found in the repository.")
+		return nil
+	}
+
+	// Display LongTitle and Body with blank line between them
+	fmt.Println(quote.LongTitle.ToANSI())
+	fmt.Println()
+	fmt.Println(quote.Body.ToANSI())
+	
+	return nil
 }
 
 func main() {

--- a/internal/core/note.go
+++ b/internal/core/note.go
@@ -677,7 +677,7 @@ func (r *Repository) DumpNotes() error {
 }
 
 func (r *Repository) LoadNoteByOID(oid oid.OID) (*Note, error) {
-	return QueryNote(CurrentDB().Client(), `WHERE oid = ?`, oid)
+	return QueryNote(CurrentDB().Client(), `WHERE oid = ?`, "", oid)
 }
 
 func (r *Repository) LoadNotes() ([]*Note, error) {
@@ -689,19 +689,19 @@ func (r *Repository) FindNotesByFileOID(oid oid.OID) ([]*Note, error) {
 }
 
 func (r *Repository) FindNoteByTitle(title string) (*Note, error) {
-	return QueryNote(CurrentDB().Client(), `WHERE title = ?`, title)
+	return QueryNote(CurrentDB().Client(), `WHERE title = ?`, "", title)
 }
 
 func (r *Repository) FindNoteBySlug(slug string) (*Note, error) {
-	return QueryNote(CurrentDB().Client(), `WHERE slug = ?`, slug)
+	return QueryNote(CurrentDB().Client(), `WHERE slug = ?`, "", slug)
 }
 
 func (r *Repository) FindNoteByHash(hash string) (*Note, error) {
-	return QueryNote(CurrentDB().Client(), `WHERE hashsum = ?`, hash)
+	return QueryNote(CurrentDB().Client(), `WHERE hashsum = ?`, "", hash)
 }
 
 func (r *Repository) FindNoteByPathAndTitle(relativePath string, title string) (*Note, error) {
-	return QueryNote(CurrentDB().Client(), `WHERE relative_path = ? AND title = ?`, relativePath, title)
+	return QueryNote(CurrentDB().Client(), `WHERE relative_path = ? AND title = ?`, "", relativePath, title)
 }
 
 func (r *Repository) FindMatchingNote(parsedNote *ParsedNote) (*Note, error) {
@@ -718,15 +718,19 @@ func (r *Repository) FindMatchingNote(parsedNote *ParsedNote) (*Note, error) {
 	}
 
 	// Last by same title or same content in the same file
-	return QueryNote(CurrentDB().Client(), `WHERE relative_path = ? AND (title = ? OR hashsum = ?)`, parsedNote.RelativePath, parsedNote.Title, parsedNote.Hash())
+	return QueryNote(CurrentDB().Client(), `WHERE relative_path = ? AND (title = ? OR hashsum = ?)`, "", parsedNote.RelativePath, parsedNote.Title, parsedNote.Hash())
 }
 
 func (r *Repository) FindNoteByWikilink(wikilink string) (*Note, error) {
-	return QueryNote(CurrentDB().Client(), `WHERE wikilink LIKE ?`, "%"+wikilink)
+	return QueryNote(CurrentDB().Client(), `WHERE wikilink LIKE ?`, "", "%"+wikilink)
 }
 
 func (r *Repository) FindNotesByWikilink(wikilink string) ([]*Note, error) {
 	return QueryNotes(CurrentDB().Client(), `WHERE wikilink LIKE ?`, "%"+wikilink)
+}
+
+func (r *Repository) GetRandomQuote() (*Note, error) {
+	return QueryNote(CurrentDB().Client(), `WHERE note_type = "Quote"`, "ORDER BY RANDOM() LIMIT 1")
 }
 
 // SearchNotes query notes to find the ones matching a list of criteria.
@@ -803,7 +807,7 @@ func (r *Repository) SearchNotes(q string) ([]*Note, error) {
 
 /* SQL Helpers */
 
-func QueryNote(db SQLClient, whereClause string, args ...any) (*Note, error) {
+func QueryNote(db SQLClient, whereClause string, randomClause string, args ...any) (*Note, error) {
 	var n Note
 	var createdAt string
 	var updatedAt string
@@ -813,8 +817,8 @@ func QueryNote(db SQLClient, whereClause string, args ...any) (*Note, error) {
 	var attributesRaw string
 	var annotationsRaw string
 
-	// Query for a value based on a single row.
-	if err := db.QueryRow(fmt.Sprintf(`
+	// Build the complete query with optional random clause
+	query := fmt.Sprintf(`
 		SELECT
 			oid,
 			packfile_oid,
@@ -840,7 +844,10 @@ func QueryNote(db SQLClient, whereClause string, args ...any) (*Note, error) {
 			marked_at,
 			annotations
 		FROM note
-		%s;`, whereClause), args...).
+		%s %s;`, whereClause, randomClause)
+
+	// Query for a value based on a single row.
+	if err := db.QueryRow(query, args...).
 		Scan(
 			&n.OID,
 			&n.PackFileOID,

--- a/internal/markdown/document.go
+++ b/internal/markdown/document.go
@@ -1,9 +1,11 @@
 package markdown
 
 import (
+	"regexp"
 	"strings"
 	"unicode"
 
+	"github.com/fatih/color"
 	"github.com/julien-sobczak/the-notewriter/internal/helpers"
 	"github.com/julien-sobczak/the-notewriter/pkg/text"
 )
@@ -55,6 +57,29 @@ func (m Document) TrimBlankLines() (result Document, countLinesAtStartTrimmed in
 // TrimSpace removes spaces at the start and end of a markdown document.
 func (m Document) TrimSpace() Document {
 	return Document(strings.TrimSpace(string(m)))
+}
+
+// ToANSI processes markdown text to replace emphasis with ANSI escape codes.
+func (m Document) ToANSI() string {
+	text := string(m)
+
+	// First handle bold emphasis (**text** and __text__)
+	boldRegex := regexp.MustCompile(`\*\*([^*]+)\*\*|__([^_]+)__`)
+	text = boldRegex.ReplaceAllStringFunc(text, func(match string) string {
+		// Extract the content between ** or __
+		content := strings.Trim(match, "*_")
+		return color.New(color.Bold).Sprint(content)
+	})
+
+	// Then handle italic emphasis (*text* and _text_)
+	italicRegex := regexp.MustCompile(`\*([^*]+)\*|_([^_]+)_`)
+	text = italicRegex.ReplaceAllStringFunc(text, func(match string) string {
+		// Extract the content between * or _
+		content := strings.Trim(match, "*_")
+		return color.New(color.Italic).Sprint(content)
+	})
+
+	return text
 }
 
 /*

--- a/internal/markdown/document_test.go
+++ b/internal/markdown/document_test.go
@@ -3,6 +3,7 @@ package markdown_test
 import (
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/julien-sobczak/the-notewriter/internal/markdown"
 	"github.com/stretchr/testify/assert"
 )
@@ -47,4 +48,62 @@ func TestIsHeading(t *testing.T) {
 	// Sub levels are not currently supported
 	ok, _, _ = markdown.IsHeading("####### Heading 7")
 	assert.False(t, ok)
+}
+
+func TestMarkdownDocument(t *testing.T) {
+
+	t.Run("ToANSI", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			input    string
+			expected string
+		}{
+			{
+				name:     "plain text",
+				input:    "This is plain text",
+				expected: "This is plain text",
+			},
+			{
+				name:     "italic text with asterisks",
+				input:    "This has *italic* text",
+				expected: "This has \x1b[3mitalic\x1b[0m text",
+			},
+			{
+				name:     "italic text with underscores",
+				input:    "This has _italic_ text",
+				expected: "This has \x1b[3mitalic\x1b[0m text",
+			},
+			{
+				name:     "bold text with double asterisks",
+				input:    "This has **bold** text",
+				expected: "This has \x1b[1mbold\x1b[0m text",
+			},
+			{
+				name:     "bold text with double underscores",
+				input:    "This has __bold__ text",
+				expected: "This has \x1b[1mbold\x1b[0m text",
+			},
+			{
+				name:     "mixed formatting",
+				input:    "This has *italic* and **bold** text",
+				expected: "This has \x1b[3mitalic\x1b[0m and \x1b[1mbold\x1b[0m text",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// fatih/color checks for non-tty output like test environment and does nothing
+				initialNoColor := color.NoColor
+				color.NoColor = false
+				t.Cleanup(func() {
+					color.NoColor = initialNoColor
+				})
+
+				doc := markdown.Document(tt.input)
+				result := doc.ToANSI()
+				assert.Equal(t, tt.expected, result, "ToANSI(%q) = %q; want %q", tt.input, result, tt.expected)
+			})
+		}
+	})
+
 }


### PR DESCRIPTION
This pull request adds a feature to display a random quote when running the nt command, showing its formatted title and body using ANSI escape codes.

Close https://github.com/julien-sobczak/the-notewriter/issues/14