### PR TITLE
feat: rework attribute definition with shorthands to support emojis

### DIFF
--- a/cmd/nt-reference/new.go
+++ b/cmd/nt-reference/new.go
@@ -31,7 +31,7 @@ var newCmd = &cobra.Command{
 		}
 
 		CheckConfig() // Useful to find reference categories
-		configReference := core.CurrentConfig().ConfigFile.References
+		configReference := core.CurrentConfigFile().References
 
 		// Step 1: Choose a category (Book, Person, etc.)
 		selectedConfigReference := ChooseCategory(configReference)

--- a/example/.nt/config.jsonnet
+++ b/example/.nt/config.jsonnet
@@ -11,5 +11,40 @@ local nt = import 'nt.libsonnet';
     },
 
     # TODO add links to the documentation
-    types: nt.DefaultTypes,
+    attributes: nt.DefaultAttributes + {
+        rating: {
+            name: "rating",
+            type: "string",
+            allowedValues: ["★", "★★", "★★★"],
+            defaultValue: "★★",
+            shorthands: {
+                "★": "★",
+                "★★": "★★",
+                "★★★": "★★★",
+            },
+        },
+    },
+
+    # TODO add links to the documentation
+    types: nt.DefaultTypes + {
+        Todo: nt.DefaultTypes.Todo + {
+            attributes: [
+                {
+                    name: "status",
+                    optional: false,
+                    inline: true,
+                },
+            ],
+        },
+        BookReview: nt.DefaultTypes.Note + {
+            name: "BookReview",
+            attributes: [
+                {
+                    name: "rating",
+                    optional: false,
+                    inline: false,
+                },
+            ],
+        },
+    },
 }

--- a/example/.nt/nt.libsonnet
+++ b/example/.nt/nt.libsonnet
@@ -1,13 +1,94 @@
 {
+    // Declare default attributes with special meaning for The NoteWriter
+    DefaultAttributes: {
+        due: {
+            name: "due",
+            description: "Due date",
+            type: "date",
+        },
+        status: {
+            name: "status",
+            aliases: ["state"],
+            description: "Status of a task",
+            type: "string",
+            options: ["todo", "in-progress", "done", "cancelled", "on-hold"],
+            defaultValue: "todo",
+            shorthands: {
+                "📝": "todo",
+                "❓": "to-refine",
+                "⏱️": "in-progress",
+                "✅": "done",
+                "❌": "cancelled",
+                "⏸️": "on-hold",
+            },
+            preserveShorthand: false,
+        },
+        priority: {
+            name: "priority",
+            description: "Priority of a task",
+            type: "string",
+            options: ["low", "medium", "high", "urgent"],
+            defaultValue: "medium",
+            shorthands: {
+                "🔽": "low",
+                "🔼": "medium",
+                "❗": "high",
+                "🚨": "urgent",
+            },
+            preserveShorthand: false,
+        },
+        rating: {
+            name: "rating",
+            description: "Rating",
+            type: "integer",
+            min: 0,
+            max: 10,
+            shorthands: {
+                "☆": 0,
+                "\u2BE8": 1,
+                "★": 2,
+                "★\u2BE8": 3,
+                "★★": 4,
+                "★★\u2BE8": 5,
+                "★★★": 6,
+                "★★★\u2BE8": 7,
+                "★★★★": 8,
+                "★★★★\u2BE8": 9,
+                "★★★★★": 10,
+            },
+            preserveShorthand: true,
+        },
+    },
+
     // Declare default note types
     DefaultTypes: {
         // Prefedefined objects = types with custom logic in The NoteWriter when processing them
         Note: {
             name: "Note",
         },
+        Task: self.Note + {
+            name: "Task",
+            attributes: [
+                {
+                    name: "status",
+                    required: true,
+                },
+                {
+                    name: "due",
+                },
+                {
+                    name: "priority",
+                },
+            ],
+        },
         Journal: self.Note + {
             name: "Journal",
-            requiredAttributes: ["date"],
+            attributes: [
+                {
+                    name: "date",
+                    required: true,
+                },
+            ],
             preprocessors: ["date-extractor"],
         },
         Quote: self.Note + {
@@ -19,7 +100,14 @@
         },
         Flashcard: self.Note + {
             name: "Flashcard",
-            optionalAttributes: ["srs.algorithm", "srs.boostFactor"],
+            attributes: [
+                {
+                    name: "srs.algorithm",
+                },
+                {
+                    name: "srs.boostFactor",
+                },
+            ],
             preprocessors: ["flashcard-extractor"],
         },
         Todo: self.Note + {
@@ -27,7 +115,14 @@
         },
         Generator: self.Note + {
             name: "Generator",
-            optionalAttributes: ["file", "interpreter"],
+            attributes: [
+                {
+                    name: "file",
+                },
+                {
+                    name: "interpreter",
+                },
+            ],
             preprocessors: ["generator"],
         },
     },

--- a/example/test-shorthands.md
+++ b/example/test-shorthands.md
@@ -1,0 +1,21 @@
+---
+title: "Test Shorthands"
+---
+
+# Test Shorthands
+
+## Todo: Add Zen Mode 🕒
+
+This is a todo with a shorthand emoji that should be parsed.
+
+## BookReview: Thinking Fast & Slow ★★★
+
+This is a book review with a rating shorthand.
+
+## Todo: Complete Project ✅
+
+This todo should be marked as done.
+
+## BookReview: Simple Book
+
+This book review should get a default rating.

--- a/internal/core/attributes.go
+++ b/internal/core/attributes.go
@@ -564,6 +564,15 @@ func CastAttribute(value any, declaredType ConfigAttribute) (any, bool) {
 	return nil, false
 }
 
+// MustCastAttribute is like CastAttribute but panics if the value cannot be cast.
+func MustCastAttribute(value any, declaredType ConfigAttribute) any {
+	typedValue, ok := CastAttribute(value, declaredType)
+	if !ok {
+		panic(fmt.Sprintf("invalid value for attribute %v: %v", declaredType, value))
+	}
+	return typedValue
+}
+
 /*
  * Markdown
  */

--- a/internal/core/commands_test.go
+++ b/internal/core/commands_test.go
@@ -282,7 +282,7 @@ func TestCommandPushPull(t *testing.T) {
 		NewTestRepository(t, FromGoldenDirNamed("TestMinimal"))
 		// Configure origin
 		origin := t.TempDir()
-		CurrentConfig().ConfigFile.Remotes = []ConfigRemote{
+		CurrentConfigFile().Remotes = []ConfigRemote{
 			{
 				Name: "origin",
 				Type: "fs",
@@ -317,7 +317,7 @@ func TestCommandPushPull(t *testing.T) {
 		// Force a new temp repository
 		NewTestRepository(t, FromGoldenDirNamed("TestMinimal"))
 		// but with the same origin
-		CurrentConfig().ConfigFile.Remotes = []ConfigRemote{
+		CurrentConfigFile().Remotes = []ConfigRemote{
 			{
 				Name: "origin",
 				Type: "fs",
@@ -336,7 +336,7 @@ func TestCommandPushPull(t *testing.T) {
 		tr := NewTestRepository(t, FromGoldenDirNamed("TestMinimal"))
 		// Configure origin
 		origin := t.TempDir()
-		CurrentConfig().ConfigFile.Remotes = []ConfigRemote{
+		CurrentConfigFile().Remotes = []ConfigRemote{
 			{
 				Name: "origin",
 				Type: "fs",

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -128,11 +128,42 @@ type ConfigFile struct {
 }
 
 // GetType returns the definition of a type of note
-func (c ConfigFile) GetType(noteType string) *ConfigType {
+func (c *ConfigFile) GetType(noteType string) (*ConfigType, bool) {
 	if obj, ok := c.Types[noteType]; ok {
+		return obj, true
+	}
+	return nil, false
+}
+
+// MustGetType returns the definition of a type of note or panics if not found
+func (c *ConfigFile) MustGetType(noteType string) *ConfigType {
+	if obj, ok := c.GetType(noteType); ok {
 		return obj
 	}
 	panic(fmt.Sprintf("Unknown type %q", noteType))
+}
+
+// GetAttribute returns the definition of an attribute
+func (c *ConfigFile) GetAttribute(name string) (*ConfigAttribute, bool) {
+	if obj, ok := c.Attributes[name]; ok {
+		return obj, true
+	}
+	return nil, false // Attributes used without a definition is allowed, unlike types
+}
+
+// GetAttributeDefaults returns the default values for required attributes of the given type of note.
+func (c ConfigFile) GetAttributeDefaults(noteType string) AttributeSet {
+	result := make(AttributeSet)
+	typeDefinition := c.MustGetType(noteType)
+	for _, attribute := range typeDefinition.RequiredAttributes() {
+		if attributeDefinition, ok := c.GetAttribute(attribute.Name); ok {
+			if attributeDefinition.DefaultValue != nil {
+				attributeValue := MustCastAttribute(attributeDefinition.DefaultValue, *attributeDefinition)
+				result[attribute.Name] = attributeValue
+			}
+		}
+	}
+	return result
 }
 
 // DefaultConfigFile is the default configuration file
@@ -146,39 +177,38 @@ func (c *ConfigLinter) Severity(name string) string {
 	return "error"
 }
 
-// GetAttribute returns the attribute with the given name.
-func (c *ConfigFile) GetAttribute(name string) (*ConfigAttribute, bool) {
-	attribute, ok := c.Attributes[name]
-	if !ok {
-		return nil, false
-	}
-	return attribute, true
-}
-
 type ConfigCore struct {
 	Extensions []string     `json:"extensions"` // List of supported file extensions (ex: "md", "markdown")
 	Medias     ConfigMedias `json:"medias"`     // Media converter configuration
 }
 type ConfigAttribute struct {
-	Name    string   `json:"name"`
-	Aliases []string `json:"aliases,omitempty"`
-	Type    string   `json:"type"`              // string, int, bool, string[], int[], bool[]
-	Format  string   `json:"format"`            // Useful for value types (ex: "markdown", "date", etc.)
-	Min     int      `json:"min,omitempty"`     // Default: 0 (for "number"-type only)
-	Max     int      `json:"max,omitempty"`     // Default: -1 (for "number"-type only)
-	Pattern string   `json:"pattern,omitempty"` // Regex (for "string"-type only)
-	Memory  *bool    `json:"memory,omitempty"`  // (for "date"-type only)
-	Inherit *bool    `json:"inherit"`           // Default: true
+	Name              string         `json:"name"`
+	Aliases           []string       `json:"aliases,omitempty"`
+	Type              string         `json:"type"`                    // string, int, bool, string[], int[], bool[]
+	Format            string         `json:"format"`                  // Useful for value types (ex: "markdown", "date", etc.)
+	Min               int            `json:"min,omitempty"`           // Default: 0 (for "number"-type only)
+	Max               int            `json:"max,omitempty"`           // Default: -1 (for "number"-type only)
+	Pattern           string         `json:"pattern,omitempty"`       // Regex (for "string"-type only)
+	Memory            *bool          `json:"memory,omitempty"`        // (for "date"-type only)
+	Inherit           *bool          `json:"inherit"`                 // Default: true
+	AllowedValues     []string       `json:"allowedValues,omitempty"` // For "string"-type only
+	Shorthands        map[string]any `json:"shorthands,omitempty"`
+	PreserveShorthand *bool          `json:"preserveShorthand"`      // Default: true
+	DefaultValue      interface{}    `json:"defaultValue,omitempty"` // For any type
+}
+
+type ConfigTypeAttribute struct {
+	Name     string `json:"name"`
+	Required *bool  `json:"required,omitempty"` // Default: false
+	Inline   *bool  `json:"inline,omitempty"`   // Default: false
 }
 
 type ConfigType struct {
-	Name               string   `json:"name"`
-	Pattern            string   `json:"pattern,omitempty"`  // Regex to detect Markdown headings matching the type
-	Preprocessors      []string `json:"preprocessors"`      // Additional logic to run after parsing a note
-	RequiredAttributes []string `json:"requiredAttributes"` // List of mandatory attributes
-	OptionalAttributes []string `json:"optionalAttributes"` // List of optional attributes
-	Hooks              []string `json:"hooks"`              // List of hooks to run on this type of note
-	// IMPROVEMENT refactor to Attributes []ConfigTypeAttribute with an attribute `required` (= more extensible)
+	Name          string                `json:"name"`
+	Pattern       string                `json:"pattern,omitempty"`    // Regex to detect Markdown headings matching the type
+	Preprocessors []string              `json:"preprocessors"`        // Additional logic to run after parsing a note
+	Attributes    []ConfigTypeAttribute `json:"attributes,omitempty"` // Structure for attributes
+	Hooks         []string              `json:"hooks"`                // List of hooks to run on this type of note
 }
 type ConfigLinter struct {
 	Rules []*ConfigLinterRule `json:"rules"` // List of rules to apply to notes
@@ -243,6 +273,27 @@ func (c *ConfigType) MatchHeading(heading string) (string, bool) {
 	return "", false
 }
 
+// RequiredAttribute checks if the given attribute is required for this type of note.
+func (c *ConfigType) RequiredAttribute(name string) bool {
+	for _, attr := range c.Attributes {
+		if attr.Name == name && attr.Required != nil && *attr.Required {
+			return true
+		}
+	}
+	return false
+}
+
+// RequiredAttributes returns the list of required attributes for this type of note.
+func (c *ConfigType) RequiredAttributes() []*ConfigTypeAttribute {
+	var requiredAttrs []*ConfigTypeAttribute
+	for _, attr := range c.Attributes {
+		if attr.Required != nil && *attr.Required {
+			requiredAttrs = append(requiredAttrs, &attr)
+		}
+	}
+	return requiredAttrs
+}
+
 // SupportExtension checks if the given file extension must be considered.
 func (f *ConfigFile) SupportExtension(path string) bool {
 	ext := strings.TrimPrefix(filepath.Ext(path), ".") // ".md" => "md"
@@ -252,6 +303,41 @@ func (f *ConfigFile) SupportExtension(path string) bool {
 		}
 	}
 	return false
+}
+
+// Valid validates a string value against this attribute's constraints.
+// Returns an empty string if valid, or an error message if invalid.
+func (c *ConfigAttribute) Valid(value any) (bool, error) {
+	// First check if the value can be cast to the correct type
+	typedValue, ok := CastAttribute(value, *c)
+	if !ok {
+		return false, fmt.Errorf("value %q is not a valid %s or cannot be converted", value, c.Type)
+	}
+
+	// Check pattern constraint (only for string type)
+	if c.Pattern != "" && c.Type == "string" {
+		if matched, err := regexp.MatchString(c.Pattern, typedValue.(string)); err != nil {
+			return false, fmt.Errorf("pattern %q is invalid: %v", c.Pattern, err)
+		} else if !matched {
+			return false, fmt.Errorf("value %q does not match pattern %q", value, c.Pattern)
+		}
+	}
+
+	// Check allowedValues constraint (only for string type)
+	if len(c.AllowedValues) > 0 && c.Type == "string" {
+		found := false
+		for _, allowedValue := range c.AllowedValues {
+			if allowedValue == value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false, fmt.Errorf("value %q is not in allowedValues %v", value, c.AllowedValues)
+		}
+	}
+
+	return true, nil
 }
 
 func (c ConfigAttribute) String() string {
@@ -651,6 +737,9 @@ func ParseConfigFile(jsonnetPath string) (*ConfigFile, error) {
 		if attribute.Inherit == nil {
 			attribute.Inherit = BoolPointer(true)
 		}
+		if attribute.PreserveShorthand == nil {
+			attribute.PreserveShorthand = BoolPointer(true)
+		}
 	}
 	// Add reserved attributes
 	if result.Attributes == nil {
@@ -663,6 +752,15 @@ func ParseConfigFile(jsonnetPath string) (*ConfigFile, error) {
 	for _, noteType := range result.Types {
 		if noteType.Pattern == "" {
 			noteType.Pattern = fmt.Sprintf("(?i)^%s:\\s*(.*)$", noteType.Name) // Ex: "Note: A basic note" or "note: A basic note"
+		}
+		// Set defaults for new attribute structure
+		for i := range noteType.Attributes {
+			if noteType.Attributes[i].Required == nil {
+				noteType.Attributes[i].Required = BoolPointer(false)
+			}
+			if noteType.Attributes[i].Inline == nil {
+				noteType.Attributes[i].Inline = BoolPointer(false)
+			}
 		}
 	}
 	// ... to decks
@@ -824,12 +922,29 @@ func (c *Config) Check() error {
 		}
 	}
 
+	// Check for default attribute values
+	for _, attribute := range c.ConfigFile.Attributes {
+		if attribute.DefaultValue != nil {
+			_, valid := CastAttribute(attribute.DefaultValue, *attribute)
+			if !valid {
+				return fmt.Errorf("default value %q for attribute %q is not valid", attribute.DefaultValue, attribute.Name)
+			}
+		}
+	}
+
 	// Check for invalid attributes
 	for _, attribute := range c.ConfigFile.Attributes {
 		// Check for invalid regex pattern
-		if attribute.Pattern != "string" {
+		if attribute.Pattern != "" && attribute.Pattern != "string" {
 			if _, err := regexp.Compile(attribute.Pattern); err != nil {
 				return fmt.Errorf("invalid pattern %q for attribute %q: %v", attribute.Pattern, attribute.Name, err)
+			}
+		}
+
+		// Check for invalid shorthand values
+		for shorthandKey, shorthandValue := range attribute.Shorthands {
+			if valid, err := attribute.Valid(shorthandValue); !valid {
+				return fmt.Errorf("shorthand value %q for key %q in attribute %q is not valid: %s", shorthandValue, shorthandKey, attribute.Name, err)
 			}
 		}
 	}

--- a/internal/core/config.jsonnet
+++ b/internal/core/config.jsonnet
@@ -2,5 +2,6 @@
 local nt = import 'nt.libsonnet';
 
 {
-    Types: nt.DefaultTypes,
+    attributes: nt.DefaultAttributes,
+    types: nt.DefaultTypes,
 }

--- a/internal/core/config.jsonnet.tmpl
+++ b/internal/core/config.jsonnet.tmpl
@@ -15,5 +15,6 @@ local nt = import 'nt.libsonnet';
     },
 
     # TODO add links to the documentation
+    attributes: nt.DefaultAttributes,
     types: nt.DefaultTypes,
 }

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -497,6 +497,95 @@ func TestParseConfigFile(t *testing.T) {
 
 }
 
+func TestConfigFile(t *testing.T) {
+
+	t.Run("GetType", func(t *testing.T) {
+		cfg := &ConfigFile{
+			Types: ConfigTypes{
+				"Note": &ConfigType{Name: "Note"},
+			},
+		}
+
+		noteType, ok := cfg.GetType("Note")
+		assert.True(t, ok)
+		require.NotNil(t, noteType)
+		assert.Equal(t, "Note", noteType.Name)
+
+		unknownType, ok := cfg.GetType("Unknown")
+		assert.False(t, ok)
+		assert.Nil(t, unknownType)
+	})
+
+	t.Run("GetAttribute", func(t *testing.T) {
+		cfg := &ConfigFile{
+			Attributes: ConfigAttributes{
+				"myattr": &ConfigAttribute{Name: "myattr"},
+			},
+		}
+
+		attr, ok := cfg.GetAttribute("myattr")
+		assert.True(t, ok)
+		require.NotNil(t, attr)
+		assert.Equal(t, "myattr", attr.Name)
+
+		unknownAttr, ok := cfg.GetAttribute("unknown")
+		assert.False(t, ok)
+		assert.Nil(t, unknownAttr)
+	})
+
+	t.Run("GetAttributeDefaults", func(t *testing.T) {
+		cfg := &ConfigFile{
+			Attributes: ConfigAttributes{
+				"attr1": &ConfigAttribute{
+					Name:         "attr1",
+					Type:         "string",
+					DefaultValue: "value1",
+				},
+				"attr2": &ConfigAttribute{
+					Name: "attr2",
+					Type: "string",
+					// no default value
+				},
+				"attr3": &ConfigAttribute{
+					Name:         "attr3",
+					Type:         "integer",
+					DefaultValue: 42,
+				},
+			},
+			Types: ConfigTypes{
+				"Note1": &ConfigType{
+					Name: "Note1",
+					Attributes: []ConfigTypeAttribute{
+						{Name: "attr1", Required: BoolPointer(true)},
+						{Name: "attr2", Required: BoolPointer(false)},
+						{Name: "attr3", Required: BoolPointer(false)}, // not required, default doesn't apply
+					},
+				},
+				"Note2": &ConfigType{
+					Name: "Note2",
+					Attributes: []ConfigTypeAttribute{
+						{Name: "attr1", Required: BoolPointer(true)},
+						{Name: "attr2", Required: BoolPointer(true)},
+						{Name: "attr3", Required: BoolPointer(true)},
+					},
+				},
+			},
+		}
+
+		defaultsNote1 := cfg.GetAttributeDefaults("Note1")
+		require.Equal(t, AttributeSet(map[string]any{
+			"attr1": "value1",
+		}), defaultsNote1)
+
+		defaultsNote2 := cfg.GetAttributeDefaults("Note2")
+		require.Equal(t, AttributeSet(map[string]any{
+			"attr1": "value1",
+			"attr3": int64(42),
+		}), defaultsNote2)
+	})
+
+}
+
 /* Test Helpers */
 
 // MustWriteTempFile creates a temporary file with the given name and content.

--- a/internal/core/database_test.go
+++ b/internal/core/database_test.go
@@ -179,7 +179,7 @@ class SillyClass:
 	assert.Equal(t, note.OID, gotoLink.NoteOID)
 	assert.Equal(t, "programming/python.md", gotoLink.RelativePath)
 	assert.Equal(t, markdown.Document("PyCon France"), gotoLink.Text)
-	assert.Equal(t, "https://www.pycon.fr/2025/", gotoLink.URL)
+	assert.Equal(t, "https://www.pycon.fr/2025/", string(gotoLink.URL))
 	assert.Equal(t, "PyCon", gotoLink.Title)
 	assert.Equal(t, "pycon-fr", gotoLink.Name)
 	assert.Equal(t, clock.Now().Truncate(time.Second), gotoLink.CreatedAt.Truncate(time.Second))

--- a/internal/core/goto.go
+++ b/internal/core/goto.go
@@ -469,17 +469,18 @@ func ExtractPlaceholders(text string) []Placeholder {
 
 		// Parse allowed values if present
 		if len(match) > 2 && match[2] != "" {
+			var options []string
 			values := strings.Split(match[2], ",")
-			for i, value := range values {
+			for _, value := range values {
 				value = strings.TrimSpace(value)
-				if value == "..." || value == "…"{
+				if value == "..." || value == "…" {
 					placeholder.Ellipsis = true
 				} else {
-					values[i] = value
+					options = append(options, value)
 				}
 			}
 
-			placeholder.Options = values
+			placeholder.Options = options
 		}
 
 		placeholders = append(placeholders, placeholder)

--- a/internal/core/goto_test.go
+++ b/internal/core/goto_test.go
@@ -65,7 +65,7 @@ func TestGoto(t *testing.T) {
 	require.NotNil(t, actual)
 	assert.Equal(t, oid.OID("42d74d967d9b4e989502647ac510777ca1e22f4a"), actual.OID) // Must have found the previous one
 	assert.Equal(t, "Go Language", actual.Text.String())
-	assert.Equal(t, "https://go.dev", actual.URL)
+	assert.Equal(t, "https://go.dev", string(actual.URL))
 
 	// Delete
 	require.NoError(t, gotoLink.Delete())
@@ -143,7 +143,7 @@ func TestParameterizedURL(t *testing.T) {
 			name     string
 			url      ParameterizedURL
 			values   map[string]string
-			expected string
+			expected ParameterizedURL
 		}{
 			{
 				name:     "No placeholders",
@@ -152,21 +152,29 @@ func TestParameterizedURL(t *testing.T) {
 				expected: "https://github.com/julien-sobczak/the-notewriter/",
 			},
 			{
-				name:     "Single simple placeholder",
-				url:      "https://github.com/julien-sobczak/the-notewriter/${page}",
-				values:   map[string]string{"page": "issues"},
+				name: "Single simple placeholder",
+				url:  "https://github.com/julien-sobczak/the-notewriter/${page}",
+				values: map[string]string{
+					"page": "issues",
+				},
 				expected: "https://github.com/julien-sobczak/the-notewriter/issues",
 			},
 			{
-				name:     "Placeholder with allowed values",
-				url:      "https://github.com/julien-sobczak/the-notewriter/${page:[issues,pulls,actions]}",
-				values:   map[string]string{"page": "pulls"},
+				name: "Placeholder with allowed values",
+				url:  "https://github.com/julien-sobczak/the-notewriter/${page:[issues,pulls,actions]}",
+				values: map[string]string{
+					"page": "pulls",
+				},
 				expected: "https://github.com/julien-sobczak/the-notewriter/pulls",
 			},
 			{
-				name:     "Multiple placeholders",
-				url:      "https://github.com/${user}/${repo}/${page:[issues,pulls]}",
-				values:   map[string]string{"user": "julien-sobczak", "repo": "the-notewriter", "page": "issues"},
+				name: "Multiple placeholders",
+				url:  "https://github.com/${user}/${repo}/${page:[issues,pulls]}",
+				values: map[string]string{
+					"user": "julien-sobczak",
+					"repo": "the-notewriter",
+					"page": "issues",
+				},
 				expected: "https://github.com/julien-sobczak/the-notewriter/issues",
 			},
 		}

--- a/internal/core/lint.go
+++ b/internal/core/lint.go
@@ -25,7 +25,7 @@ type LintResult struct {
 
 // Append merges new violations into the current result.
 func (r *LintResult) Append(violations ...*Violation) {
-	linter := CurrentConfig().ConfigFile.Linter
+	linter := CurrentConfigFile().Linter
 	for _, violation := range violations {
 		if linter.Severity(violation.Name) == "warning" {
 			r.Warnings = append(r.Warnings, violation)
@@ -526,8 +526,8 @@ func CheckAttributes(file *ParsedFile) ([]*Violation, error) {
 
 	for _, note := range file.Notes {
 
-		attributeDefinitions := CurrentConfig().ConfigFile.Attributes
-		objectDefinition := CurrentConfig().ConfigFile.GetType(note.Type)
+		attributeDefinitions := CurrentConfigFile().Attributes
+		objectDefinition := CurrentConfigFile().MustGetType(note.Type)
 
 		for _, attributeDefinition := range attributeDefinitions {
 
@@ -546,26 +546,14 @@ func CheckAttributes(file *ParsedFile) ([]*Violation, error) {
 					found = true
 
 					line := text.LineNumber(string(file.Markdown.Content), name+":")
-					if _, ok := CastAttribute(fileValue, *attributeDefinition); !ok {
+					stringValue := fmt.Sprintf("%s", fileValue)
+					if valid, err := attributeDefinition.Valid(stringValue); !valid {
 						violations = append(violations, &Violation{
 							Name:         "check-attributes",
 							RelativePath: file.RelativePath,
-							Message:      fmt.Sprintf("attribute %q in file %q is not a valid %s or cannot be converted", name, file.Title, attributeDefinition.Type),
+							Message:      fmt.Sprintf("attribute %q in file %q: %s", name, file.Title, err),
 							Line:         line,
 						})
-					} else if attributeDefinition.Pattern != "" {
-						// Check pattern
-						regexAttribute := regexp.MustCompile(attributeDefinition.Pattern)
-						// Convert value to string
-						stringValue := fmt.Sprintf("%s", fileValue)
-						if !regexAttribute.MatchString(stringValue) {
-							violations = append(violations, &Violation{
-								Name:         "check-attributes",
-								RelativePath: file.RelativePath,
-								Message:      fmt.Sprintf("attribute %q in file %q does not match pattern %q", name, file.Title, attributeDefinition.Pattern),
-								Line:         line,
-							})
-						}
 					}
 				}
 
@@ -574,32 +562,37 @@ func CheckAttributes(file *ParsedFile) ([]*Violation, error) {
 					found = true
 
 					line := text.LineNumber(string(file.Markdown.Content), name+":")
-					if _, ok := CastAttribute(noteValue, *attributeDefinition); !ok {
+					stringValue := fmt.Sprintf("%s", noteValue)
+					if valid, err := attributeDefinition.Valid(stringValue); !valid {
 						violations = append(violations, &Violation{
 							Name:         "check-attributes",
 							RelativePath: file.RelativePath,
-							Message:      fmt.Sprintf("attribute %q on note %q in file %q is not a valid %s or cannot be converted", name, note.Title, file.RelativePath, attributeDefinition.Type),
+							Message:      fmt.Sprintf("attribute %q on note %q in file %q: %s", name, note.Title, file.RelativePath, err),
 							Line:         line,
 						})
-					} else if attributeDefinition.Pattern != "" {
-						// Check pattern
-						regexAttribute := regexp.MustCompile(attributeDefinition.Pattern)
-						// Convert value to string
-						stringValue := fmt.Sprintf("%s", noteValue)
-						if !regexAttribute.MatchString(stringValue) {
-							violations = append(violations, &Violation{
-								Name:         "check-attributes",
-								RelativePath: file.RelativePath,
-								Message:      fmt.Sprintf("attribute %q on note %q in file %q does not match pattern %q", name, note.Title, file.RelativePath, attributeDefinition.Pattern),
-								Line:         line,
-							})
-						}
+					}
+				}
+
+				// Also check the merged attributes (which include defaults and inherited values)
+				mergedValue, presentInMerged := note.Attributes[name]
+				if presentInMerged && !presentOnNote && !presentOnFile {
+					found = true
+					// This is an attribute that comes from defaults or inheritance
+					stringValue := fmt.Sprintf("%s", mergedValue)
+					if valid, err := attributeDefinition.Valid(stringValue); !valid {
+						violations = append(violations, &Violation{
+							Name:         "check-attributes",
+							RelativePath: file.RelativePath,
+							Message:      fmt.Sprintf("attribute %q on note %q in file %q: %s", name, note.Title, file.RelativePath, err),
+							Line:         note.Line,
+						})
 					}
 				}
 			}
 
-			// Check required
-			if slices.Contains(objectDefinition.RequiredAttributes, attributeDefinition.Name) && !found {
+			// Check required attributes
+			required := objectDefinition.RequiredAttribute(attributeDefinition.Name)
+			if required && !found {
 				violations = append(violations, &Violation{
 					Name:         "check-attributes",
 					RelativePath: file.RelativePath,
@@ -607,10 +600,10 @@ func CheckAttributes(file *ParsedFile) ([]*Violation, error) {
 					Line:         note.Line,
 				})
 			}
-
-			// Nothing more to check
-			continue
 		}
+
+		// Nothing more to check
+		continue
 	}
 
 	return violations, nil
@@ -621,7 +614,7 @@ func CheckAttributes(file *ParsedFile) ([]*Violation, error) {
 func (f *ParsedFile) Lint(ruleNames []string) ([]*Violation, error) {
 	var violations []*Violation
 
-	rules := CurrentConfig().ConfigFile.Linter.Rules
+	rules := CurrentConfigFile().Linter.Rules
 	for _, configRule := range rules {
 		fn := LintRulesFn[configRule.Name]
 

--- a/internal/core/lint_test.go
+++ b/internal/core/lint_test.go
@@ -362,7 +362,7 @@ func TestCheckAttributes(t *testing.T) {
 		},
 		{
 			Name:         "check-attributes",
-			Message:      `attribute "isbn" on note "Note: _Steve Jobs_ by Walter Isaacson" in file "check-attributes.md" does not match pattern "^([0-9-]{10}|[0-9]{3}-[0-9]{10})$"`,
+			Message:      `attribute "isbn" on note "Note: _Steve Jobs_ by Walter Isaacson" in file "check-attributes.md": value "INVALID" does not match pattern "^([0-9-]{10}|[0-9]{3}-[0-9]{10})$"`,
 			RelativePath: "check-attributes.md",
 			Line:         14,
 		},

--- a/internal/core/nt.libsonnet
+++ b/internal/core/nt.libsonnet
@@ -1,13 +1,94 @@
 {
+    // Declare default attributes with special meaning for The NoteWriter
+    DefaultAttributes: {
+        due: {
+            name: "due",
+            description: "Due date",
+            type: "date",
+        },
+        status: {
+            name: "status",
+            aliases: ["state"],
+            description: "Status of a task",
+            type: "string",
+            options: ["todo", "in-progress", "done", "cancelled", "on-hold"],
+            defaultValue: "todo",
+            shorthands: {
+                "📝": "todo",
+                "❓": "to-refine",
+                "⏱️": "in-progress",
+                "✅": "done",
+                "❌": "cancelled",
+                "⏸️": "on-hold",
+            },
+            preserveShorthand: false,
+        },
+        priority: {
+            name: "priority",
+            description: "Priority of a task",
+            type: "string",
+            options: ["low", "medium", "high", "urgent"],
+            defaultValue: "medium",
+            shorthands: {
+                "🔽": "low",
+                "🔼": "medium",
+                "❗": "high",
+                "🚨": "urgent",
+            },
+            preserveShorthand: false,
+        },
+        rating: {
+            name: "rating",
+            description: "Rating",
+            type: "integer",
+            min: 0,
+            max: 10,
+            shorthands: {
+                "☆": 0,
+                "\u2BE8": 1,
+                "★": 2,
+                "★\u2BE8": 3,
+                "★★": 4,
+                "★★\u2BE8": 5,
+                "★★★": 6,
+                "★★★\u2BE8": 7,
+                "★★★★": 8,
+                "★★★★\u2BE8": 9,
+                "★★★★★": 10,
+            },
+            preserveShorthand: true,
+        },
+    },
+
     // Declare default note types
     DefaultTypes: {
         // Prefedefined objects = types with custom logic in The NoteWriter when processing them
         Note: {
             name: "Note",
         },
+        Task: self.Note + {
+            name: "Task",
+            attributes: [
+                {
+                    name: "status",
+                    required: true,
+                },
+                {
+                    name: "due",
+                },
+                {
+                    name: "priority",
+                },
+            ],
+        },
         Journal: self.Note + {
             name: "Journal",
-            requiredAttributes: ["date"],
+            attributes: [
+                {
+                    name: "date",
+                    required: true,
+                },
+            ],
             preprocessors: ["date-extractor"],
         },
         Quote: self.Note + {
@@ -19,7 +100,14 @@
         },
         Flashcard: self.Note + {
             name: "Flashcard",
-            optionalAttributes: ["srs.algorithm", "srs.boostFactor"],
+            attributes: [
+                {
+                    name: "srs.algorithm",
+                },
+                {
+                    name: "srs.boostFactor",
+                },
+            ],
             preprocessors: ["flashcard-extractor"],
         },
         Todo: self.Note + {
@@ -27,7 +115,14 @@
         },
         Generator: self.Note + {
             name: "Generator",
-            optionalAttributes: ["file", "interpreter"],
+            attributes: [
+                {
+                    name: "file",
+                },
+                {
+                    name: "interpreter",
+                },
+            ],
             preprocessors: ["generator"],
         },
     },

--- a/internal/core/parser.go
+++ b/internal/core/parser.go
@@ -296,7 +296,6 @@ func (p *ParsedFile) extractNotes() ([]*ParsedNote, error) {
 		noteContent := section.ContentText.MustTransform(StripSubNotesTransformer)
 
 		noteBody := noteContent.ExtractLines(2, -1) // Trim heading
-
 		if noteBody.IsBlank() {
 			// skip sections without text (= category to organize notes, not really free notes)
 			continue
@@ -312,6 +311,24 @@ func (p *ParsedFile) extractNotes() ([]*ParsedNote, error) {
 		if !supported {
 			// Ex: top-level heading, subsections inside a "Note:" already included in the containing note, ...
 			continue
+		}
+
+		// Process shorthands from shortTitle
+		extractedAttributes := ExtractShorthands(string(shortTitle), CurrentConfigFile().Attributes)
+
+		// Apply extracted shorthand attributes
+		for attrName, attrValue := range extractedAttributes {
+			noteAttributes[attrName] = attrValue
+		}
+
+		// Update titles by removing shorthands only if not-preservable
+		modifiedTitle := RemoveShorthands(string(title), CurrentConfigFile().Attributes)
+		if modifiedTitle != string(title) {
+			title = markdown.Document(modifiedTitle)
+		}
+		modifiedShortTitle := RemoveShorthands(string(shortTitle), CurrentConfigFile().Attributes)
+		if modifiedShortTitle != string(shortTitle) {
+			shortTitle = markdown.Document(modifiedShortTitle)
 		}
 
 		// Ignore ignorabled notes
@@ -384,6 +401,10 @@ func (p *ParsedFile) extractNotes() ([]*ParsedNote, error) {
 		if noteType.Hooks != nil {
 			attributes.AddHook(noteType.Hooks...)
 		}
+
+		// Apply default values for missing required attributes
+		defaultAttributes := CurrentConfigFile().GetAttributeDefaults(noteType.Name)
+		attributes = defaultAttributes.Merge(attributes)
 
 		// Determine the long title
 		var titles []markdown.Document
@@ -510,7 +531,7 @@ func FilterNonInheritableAttributes(attributeSet AttributeSet) AttributeSet {
 	// (ex: tags are not inheritable)
 	filtered := make(AttributeSet)
 	for key, value := range attributeSet {
-		attributeConfig, ok := CurrentConfig().ConfigFile.GetAttribute(key)
+		attributeConfig, ok := CurrentConfigFile().GetAttribute(key)
 		if !ok || *attributeConfig.Inherit {
 			// Undefined attribute are inherited by default
 			filtered[key] = value
@@ -920,4 +941,91 @@ func (n *ParsedNote) Matches(query *Query) bool {
 	// query.Terms is not supported as parsed notes are still not indexed
 
 	return true
+}
+
+// ExtractShorthands extracts shorthand attributes from a string
+func ExtractShorthands(text string, attributes ConfigAttributes) AttributeSet {
+	extractedAttributes := make(AttributeSet)
+
+	for _, attribute := range attributes {
+		if len(attribute.Shorthands) == 0 {
+			continue
+		}
+
+		// Sort shorthand keys by length (longest first) to match longer patterns first
+		var sortedKeys []string
+		for shorthandKey := range attribute.Shorthands {
+			sortedKeys = append(sortedKeys, shorthandKey)
+		}
+		// Simple sort by length (longest first)
+		for i := 0; i < len(sortedKeys); i++ {
+			for j := i + 1; j < len(sortedKeys); j++ {
+				if len(sortedKeys[i]) < len(sortedKeys[j]) {
+					sortedKeys[i], sortedKeys[j] = sortedKeys[j], sortedKeys[i]
+				}
+			}
+		}
+
+		// Look for each shorthand key in the text (longest first)
+		for _, shorthandKey := range sortedKeys {
+			if strings.Contains(text, shorthandKey) {
+				shorthandValue := attribute.Shorthands[shorthandKey]
+				typedValue := MustCastAttribute(shorthandValue, *attribute)
+				extractedAttributes[attribute.Name] = typedValue
+				break // Only match the first shorthand for this attribute
+			}
+		}
+	}
+
+	return extractedAttributes
+}
+
+// RemoveShorthands removes shorthands from text only if marked as non-preservable.
+func RemoveShorthands(text string, attributes ConfigAttributes) string {
+	modifiedText := text
+
+	for _, attribute := range attributes {
+		if attribute.PreserveShorthand == nil || *attribute.PreserveShorthand {
+			continue
+		}
+
+		if len(attribute.Shorthands) == 0 {
+			continue
+		}
+
+		// Sort shorthand keys by length (longest first) to remove longer patterns first
+		var sortedKeys []string
+		for shorthandKey := range attribute.Shorthands {
+			sortedKeys = append(sortedKeys, shorthandKey)
+		}
+		// Simple sort by length (longest first)
+		for i := 0; i < len(sortedKeys); i++ {
+			for j := i + 1; j < len(sortedKeys); j++ {
+				if len(sortedKeys[i]) < len(sortedKeys[j]) {
+					sortedKeys[i], sortedKeys[j] = sortedKeys[j], sortedKeys[i]
+				}
+			}
+		}
+
+		// Remove shorthand keys from text (longest first)
+		for _, shorthandKey := range sortedKeys {
+			if strings.Contains(modifiedText, shorthandKey) {
+				modifiedText = strings.ReplaceAll(modifiedText, shorthandKey, "")
+				break // Only remove the first match for this attribute
+			}
+		}
+	}
+
+	// Remove U+FE0F used to request the emoji presentation of a character that can be displayed either as text or emoji (see https://unicode.org/faq/emoji_dingbats.html)
+	modifiedText = strings.Map(func(r rune) rune {
+		if r == '\uFE0F' {
+			return -1
+		}
+		return r
+	}, modifiedText)
+
+	// Clean up consecutive spaces and trim
+	modifiedText = strings.TrimSpace(regexp.MustCompile(`\s+`).ReplaceAllString(modifiedText, " "))
+
+	return modifiedText
 }

--- a/internal/core/parser_test.go
+++ b/internal/core/parser_test.go
@@ -46,7 +46,7 @@ func TestParseFileWithTestdata(t *testing.T) {
 				// File attributes extracted from the Front Matter
 				assert.Equal(t, core.AttributeSet(map[string]any{
 					"title":  "Basic Note-Taking",
-					"rating": 5,
+					"rating": int64(5),
 					"slug":   "basic-notetaking",
 					"tags":   []string{"thinking"},
 				}), file.FileAttributes)
@@ -86,7 +86,7 @@ func TestParseFileWithTestdata(t *testing.T) {
 				assert.Equal(t, "## Note: A Note\n\nNotes has many uses:\n\n* Journaling\n* To-Do list\n* Drawing\n* Diary\n* Flashcard\n* Reminder", noteNote.Content.String())
 				assert.Equal(t, "Notes has many uses:\n\n* Journaling\n* To-Do list\n* Drawing\n* Diary\n* Flashcard\n* Reminder", noteNote.Body.String())
 				assert.Equal(t, core.AttributeSet{
-					"rating": 5,
+					"rating": int64(5),
 					"tags":   []string{"thinking"},
 				}, noteNote.Attributes)
 				// No subobjects
@@ -102,7 +102,7 @@ func TestParseFileWithTestdata(t *testing.T) {
 				}), noteTimFerris.NoteAttributes)
 				require.Equal(t, core.AttributeSet(map[string]any{
 					"author": "Tim Ferris",
-					"rating": 5,
+					"rating": int64(5),
 					"tags":   []string{"thinking"},
 				}), noteTimFerris.Attributes)
 
@@ -124,7 +124,7 @@ func TestParseFileWithTestdata(t *testing.T) {
 				}), noteDaVinci.NoteAttributes)
 				require.Equal(t, core.AttributeSet(map[string]any{
 					"author": "Leonardo da Vinci",
-					"rating": 5,
+					"rating": int64(5),
 					"tags":   []string{"thinking"},
 					"year":   "~1510",
 				}), noteDaVinci.Attributes)
@@ -203,6 +203,34 @@ func TestParseFileWithTestdata(t *testing.T) {
 				assert.NotContains(t, note.Body.String(), "Flashcard: First Notebooks")
 
 				// TODO complete
+			},
+		},
+
+		{
+			name:   "Shorthands",
+			golden: "Shorthands",
+			test: func(t *testing.T, file *core.ParsedFile) {
+				require.NotNil(t, file)
+
+				// Check notes for modified titles and extracted attributes
+				assert.Len(t, file.Notes, 2)
+				note1 := file.Notes[0]
+				note2 := file.Notes[1]
+
+				assert.Equal(t, "Shorthands Demo / Support emojis in title as attributes", note1.LongTitle.String())
+				assert.Equal(t, "Task: Support emojis in title as attributes", note1.Title.String())
+				assert.Equal(t, "Support emojis in title as attributes", note1.ShortTitle.String())
+				assert.Equal(t, core.AttributeSet(map[string]any{
+					"status":   "in-progress",
+					"priority": "high",
+				}), note1.Attributes)
+
+				assert.Equal(t, "Shorthands Demo / Review _Building a Second Brain_ ★★★★", note2.LongTitle.String())
+				assert.Equal(t, "Note: Review _Building a Second Brain_ ★★★★", note2.Title.String())
+				assert.Equal(t, "Review _Building a Second Brain_ ★★★★", note2.ShortTitle.String())
+				assert.Equal(t, core.AttributeSet(map[string]any{
+					"rating": int64(8),
+				}), note2.Attributes)
 			},
 		},
 
@@ -878,7 +906,12 @@ local nt = import 'nt.libsonnet';
 		// A new type similar to existing ones
 		BookReview: nt.DefaultTypes.Note + {
 			name: "BookReview",
-			requiredAttributes: ["isbn"],
+			attributes: [
+				{
+					name: "isbn",
+					required: true,
+				},
+			],
 		},
 
 		// A new type with a custom pattern
@@ -1024,6 +1057,83 @@ func TestReplaceMedias(t *testing.T) {
 			result, err := doc.Transform(transformer)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result.String())
+		})
+	}
+}
+
+func TestShorthands(t *testing.T) {
+	attributes := core.ConfigAttributes{
+		"status": &core.ConfigAttribute{
+			Name: "status",
+			Type: "string",
+			Shorthands: map[string]any{
+				"📋": "todo",
+				"🕒": "in-progress",
+				"⛔": "blocked",
+				"✅": "done",
+			},
+			PreserveShorthand: core.BoolPointer(false), // Remove from title
+		},
+		"rating": &core.ConfigAttribute{
+			Name: "rating",
+			Type: "string",
+			Shorthands: map[string]any{
+				"★":   "★",
+				"★★":  "★★",
+				"★★★": "★★★",
+			},
+			PreserveShorthand: core.BoolPointer(true), // Keep in title
+		},
+	}
+
+	tests := []struct {
+		name               string
+		text               string
+		expectedText       string
+		expectedAttributes core.AttributeSet
+	}{
+		{
+			name:         "Status shorthand removed",
+			text:         "Add Zen Mode 🕒",
+			expectedText: "Add Zen Mode",
+			expectedAttributes: map[string]any{
+				"status": "in-progress",
+			},
+		},
+		{
+			name:         "Rating shorthand preserved",
+			text:         "Great Book ★★★",
+			expectedText: "Great Book ★★★",
+			expectedAttributes: map[string]any{
+				"rating": "★★★",
+			},
+		},
+		{
+			name:         "Status shorthand at beginning",
+			text:         "Add 🕒 Zen Mode",
+			expectedText: "Add Zen Mode",
+			expectedAttributes: map[string]any{
+				"status": "in-progress",
+			},
+		},
+		{
+			name:         "Multiple emojis",
+			text:         "Add Zen Mode 🕒 ★★",
+			expectedText: "Add Zen Mode ★★",
+			expectedAttributes: map[string]any{
+				"status": "in-progress",
+				"rating": "★★",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Test extraction
+			actualText := core.RemoveShorthands(test.text, attributes)
+			actualAttributes := core.ExtractShorthands(test.text, attributes)
+			assert.Equal(t, test.expectedText, actualText)
+			assert.Equal(t, test.expectedAttributes, actualAttributes)
 		})
 	}
 }

--- a/internal/core/testdata/TestLint/.nt/config.jsonnet
+++ b/internal/core/testdata/TestLint/.nt/config.jsonnet
@@ -33,7 +33,12 @@ local nt = import 'nt.libsonnet';
 
     types: nt.DefaultTypes + {
         Quote: nt.DefaultTypes.Quote + {
-            requiredAttributes: ["name"],
+            attributes: [
+                {
+                    name: "name",
+                    required: true,
+                },
+            ],
         },
     },
 

--- a/internal/core/testdata/TestLint/no-implicit-slug-on-flashcard.md
+++ b/internal/core/testdata/TestLint/no-implicit-slug-on-flashcard.md
@@ -10,10 +10,10 @@ No slug is required on notes without flashcards.
 
 ## Flashcard: A flashcard without slug
 
-A flashcard with a slug [[c1::implicitely]] defined
+A flashcard with a slug [{c1::implicitely}] defined
 
 ## Flashcard; A flashcard with slug
 
 `@slug: a-flashcard-with-slug`
 
-A flashcard with a slug [[c1::explicitely]] defined.
+A flashcard with a slug [{c1::explicitely}] defined.

--- a/internal/core/testdata/TestParser/shorthands.md
+++ b/internal/core/testdata/TestParser/shorthands.md
@@ -1,0 +1,13 @@
+# Shorthands Demo
+
+## Task: Support emojis in title as attributes ❗️ ⏱️
+
+The emojis are equivalent to the following attributes.
+
+```md
+`@priority: high` `@status: in-progress`
+```
+
+## Note: Review _Building a Second Brain_ ★★★★
+
+TODO write the review


### PR DESCRIPTION
Close #23

Improve how note types and attributes are defined. 

The new format support more extensible metadata, including default values, allowed values, shorthands.